### PR TITLE
Formalize `anyguard` detection contract in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,60 @@ Packages:
 - Exit `2`: invalid CLI usage or flag parsing error.
 - On diagnostics, prints `file:line:column` and a reason.
 
+### Detection Contract
+
+`anyguard` is syntax driven. It only reports `any` when the identifier is the direct child of one of the AST slots below. Anything not listed is unsupported and is not detected or reported (you are welcome to contribute).
+
+| Parent AST node | Child slot | Supported syntax |
+| --- | --- | --- |
+| `*ast.Field` | `Type` | Parameter types, result types, struct field types, and interface field or member types |
+| `*ast.ValueSpec` | `Type` | Explicit variable declaration types |
+| `*ast.TypeSpec` | `Type` | Type alias and type definition right hand sides |
+| `*ast.TypeAssertExpr` | `Type` | Type assertions such as `value.(any)` |
+| `*ast.ArrayType` | `Elt` | Array and slice element types |
+| `*ast.MapType` | `Key`, `Value` | Map key and value types |
+| `*ast.ChanType` | `Value` | Channel element types |
+| `*ast.StarExpr` | `X` | Pointer target types |
+| `*ast.Ellipsis` | `Elt` | Variadic parameter element types |
+| `*ast.CallExpr` | `Fun` | `any(...)` forms matched by syntax only |
+| `*ast.IndexExpr` | `Index` | `T[any]` and `value[any]` forms matched by syntax only |
+| `*ast.IndexListExpr` | `Indices[i]` | `T[int, any]` style forms matched by syntax only |
+
+Nested `any` is reportable only when the nested identifier still appears in one of those slots. For example, `map[string][]any` reports because the innermost `any` is the `Elt` of an `*ast.ArrayType`.
+
+Unsupported and ambiguous cases:
+
+- Type parameter constraints such as `func Use[T any](v T) {}` and `type Box[T any] struct{}`
+- In those examples, `any` constrains `T`. It is not a concrete type position like `func Use(v any) {}` or `type Value = any`
+- Any `any` occurrence whose direct parent child AST relationship is not listed above
+- Identifier names, selectors, assignments, composite literal elements, return expressions, type switch case lists, comments, and string literals
+- No type info is used. `any(...)`, `T[any]`, and `T[int, any]` are matched by syntax alone because those exact AST child slots are part of the compatibility contract
+- Example false positive, a user function named `any` that is called as `any(1)` reports because the callee matches `*ast.CallExpr.Fun`
+- Example false positive, a value named `any` used in `values[any]` reports because the index matches `*ast.IndexExpr.Index`
+- Example false positive, `Box[int, any]` style syntax reports because the second slot matches `*ast.IndexListExpr.Indices[i]`
+- These syntax-only matches can be suppressed with a file scoped or symbol scoped allowlist entry, or with `//nolint:anyguard` on the same line or the previous line
+
+Finding identity:
+
+- File identity is the normalized repository-relative path used for allowlist matching and `Error.File`
+- Paths use slash separators and omit a leading `./`
+- Owner identity is the first enclosing top level declaration range that contains the finding
+- `*ast.TypeSpec` uses the type name
+- `*ast.ValueSpec` uses declared names in source order
+- `*ast.FuncDecl` uses the function name, or the receiver type name for methods
+- Local declarations inside a function or method inherit that enclosing function or receiver type owner
+- File scoped allowlist entries match by path only
+- Symbol scoped allowlist entries match by `{path, owner}`
+- If no owner resolves, symbol scoped matching fails closed and only a file scoped allowlist entry can suppress the finding
+
+Failure semantics:
+
+- Allowlist read, parse, and validation errors halt analysis with an error
+- Root resolution, filesystem traversal, and Go parse errors halt CLI validation with an error
+- Analyzer path resolution fails only after repository root, GOPATH, and package path derivation have all failed
+- Analyzer files with no filename or no token file are skipped
+- Changing the supported slots above requires an explicit README update because this section is the public compatibility contract
+
 ### Development
 
 ```bash


### PR DESCRIPTION
## Summary

This PR adds a formal detection contract to the README so `anyguard` has a documented compatibility surface for `any` detection.

Resolves: #2 

## Why

The current behavior is understandable from the implementation, but it was not yet strict enough to serve as a public contract. That made it harder to reason about:

- exactly which syntax categories are supported
- which cases are unsupported by default
- where syntax-only matching can produce ambiguity or false positives
- how findings are identified for allowlist matching
- how the analyzer behaves when path or ownership resolution is incomplete

## What changed

This PR adds a README section that defines:

- the exhaustive list of supported AST slots that can produce findings
- unsupported and ambiguous cases that are out of scope by default
- the rule that findings only come from explicit AST child slots
- the finding identity model for file and owner matching
- failure semantics for allowlist, path, and analyzer file resolution
- concrete syntax-only false-positive examples for `any(...)`, `values[any]`, and `Box[int, any]`
- the documented suppression paths for those cases via allowlist entries or `//nolint:anyguard`

## Scope

- Documentation only
- No analyzer behavior changes
- No allowlist schema changes
- No feature expansion

## Verification

Ran successfully:

- `go build ./...`
- `go test ./...`
- `go test -race -v ./...`
- `go test -bench=. -run=^$ ./...`
- `golangci-lint run`
- `bash ./scripts/ci/build-custom-gcl.sh`
- `bash ./scripts/ci/run-golangci-plugin-smoke.sh