### PR TITLE
Refactor any usage findings to use canonical syntax-owned identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,14 @@ Finding identity:
 
 - File identity is the normalized repository-relative path used for allowlist matching and `Error.File`
 - Paths use slash separators and omit a leading `./`
-- Owner identity is the first enclosing top level declaration range that contains the finding
+- Owner identity is derived directly from the owning syntax node at collection time, not from positional or range overlap
 - `*ast.TypeSpec` uses the type name
-- `*ast.ValueSpec` uses declared names in source order
+- `*ast.ValueSpec` uses the first declared name in source order
 - `*ast.FuncDecl` uses the function name, or the receiver type name for methods
 - Local declarations inside a function or method inherit that enclosing function or receiver type owner
+- Category identity is the supported AST slot label captured at collection time, for example `*ast.MapType.Value`
 - File scoped allowlist entries match by path only
-- Symbol scoped allowlist entries match by `{path, owner}`
+- Symbol scoped allowlist entries match by the collected `{path, owner}` identity
 - If no owner resolves, symbol scoped matching fails closed and only a file scoped allowlist entry can suppress the finding
 
 Failure semantics:

--- a/internal/validation/any_usage.go
+++ b/internal/validation/any_usage.go
@@ -28,10 +28,18 @@ var nolintDirectiveRE = regexp.MustCompile(`(?i)\bnolint(?::([a-z0-9_,-]+))?`)
 
 // Error represents a single disallowed `any` usage.
 type Error struct {
-	File    string
-	Line    int
-	Message string
-	Code    string
+	File     string // File mirrors Identity.File for existing callers.
+	Line     int
+	Message  string
+	Code     string
+	Identity FindingIdentity
+}
+
+// FindingIdentity is the canonical identity for a collected any-usage finding.
+type FindingIdentity struct {
+	File     string
+	Owner    string
+	Category string
 }
 
 // AnyAllowlist captures approved any-usage locations for enforcement.
@@ -241,13 +249,21 @@ func normalizeSymbols(symbols []string) []string {
 
 type anyAllowlistIndex struct {
 	allowAll map[string]bool
-	symbols  map[string]map[string]struct{}
+	scoped   map[anyAllowlistSelector]struct{}
+}
+
+// anyAllowlistSelector leaves category unset for the current allowlist format,
+// but retains it so matching can support category-scoped selectors exactly.
+type anyAllowlistSelector struct {
+	file     string
+	owner    string
+	category string
 }
 
 func buildAllowlistIndex(allowlist AnyAllowlist) anyAllowlistIndex {
 	index := anyAllowlistIndex{
 		allowAll: make(map[string]bool),
-		symbols:  make(map[string]map[string]struct{}),
+		scoped:   make(map[anyAllowlistSelector]struct{}),
 	}
 
 	for _, entry := range allowlist.Entries {
@@ -256,29 +272,38 @@ func buildAllowlistIndex(allowlist AnyAllowlist) anyAllowlistIndex {
 			continue
 		}
 
-		if _, ok := index.symbols[entry.Path]; !ok {
-			index.symbols[entry.Path] = make(map[string]struct{})
-		}
 		for _, symbol := range entry.Symbols {
-			index.symbols[entry.Path][symbol] = struct{}{}
+			index.scoped[anyAllowlistSelector{
+				file:  entry.Path,
+				owner: symbol,
+			}] = struct{}{}
 		}
 	}
 
 	return index
 }
 
-func (index anyAllowlistIndex) isAllowed(relPath, symbol string) bool {
-	if index.allowAll[relPath] {
+func (index anyAllowlistIndex) isAllowed(identity FindingIdentity) bool {
+	if index.allowAll[identity.File] {
 		return true
 	}
-	if symbol == "" {
+	if identity.Owner == "" {
 		return false
 	}
-	allowedSymbols, ok := index.symbols[relPath]
-	if !ok {
-		return false
+
+	_, ok := index.scoped[anyAllowlistSelector{
+		file:     identity.File,
+		owner:    identity.Owner,
+		category: identity.Category,
+	}]
+	if ok {
+		return true
 	}
-	_, ok = allowedSymbols[symbol]
+
+	_, ok = index.scoped[anyAllowlistSelector{
+		file:  identity.File,
+		owner: identity.Owner,
+	}]
 	return ok
 }
 
@@ -296,7 +321,7 @@ func validateAnyFile(path, relPath string, index anyAllowlistIndex) ([]Error, er
 	}
 
 	nolintLines := collectNolintLines(file, fset)
-	uses := collectAnyUsages(file)
+	uses := collectAnyUsages(relPath, file)
 	if len(uses) == 0 {
 		return nil, nil
 	}
@@ -309,26 +334,27 @@ func validateAnyFile(path, relPath string, index anyAllowlistIndex) ([]Error, er
 			continue
 		}
 
-		if index.isAllowed(relPath, usage.owner) {
+		if index.isAllowed(usage.identity) {
 			continue
 		}
 
-		violations = append(violations, newViolation(relPath, pos.Line, lines))
+		violations = append(violations, newViolation(usage.identity, pos.Line, lines))
 	}
 
 	return violations, nil
 }
 
-func newViolation(relPath string, line int, lines []string) Error {
+func newViolation(identity FindingIdentity, line int, lines []string) Error {
 	code := ""
 	if line > 0 && line <= len(lines) {
 		code = strings.TrimSpace(lines[line-1])
 	}
 	return Error{
-		File:    relPath,
-		Line:    line,
-		Message: "disallowed any usage; add allowlist entry, use //nolint:anyguard, or replace with a concrete type",
-		Code:    code,
+		File:     identity.File,
+		Line:     line,
+		Message:  "disallowed any usage; add allowlist entry, use //nolint:anyguard, or replace with a concrete type",
+		Code:     code,
+		Identity: identity,
 	}
 }
 
@@ -395,18 +421,19 @@ const (
 )
 
 type anyUsage struct {
-	category anyUsageCategory
-	owner    string
+	identity FindingIdentity
 	pos      token.Pos
 }
 
 // anyUsageCollector records findings only from explicitly supported AST slots.
 type anyUsageCollector struct {
+	file   string
 	usages []anyUsage
 }
 
-func collectAnyUsages(file *ast.File) []anyUsage {
+func collectAnyUsages(relPath string, file *ast.File) []anyUsage {
 	collector := anyUsageCollector{
+		file:   normalizePath(relPath),
 		usages: make([]anyUsage, 0),
 	}
 	collector.inspectFile(file)
@@ -518,12 +545,19 @@ func (collector *anyUsageCollector) visitSupportedSlot(category anyUsageCategory
 	ident, ok := expr.(*ast.Ident)
 	if ok && ident.Name == "any" {
 		collector.usages = append(collector.usages, anyUsage{
-			category: category,
-			owner:    owner,
+			identity: newFindingIdentity(collector.file, owner, category),
 			pos:      ident.Pos(),
 		})
 	}
 	collector.inspectNode(expr, owner)
+}
+
+func newFindingIdentity(relPath, owner string, category anyUsageCategory) FindingIdentity {
+	return FindingIdentity{
+		File:     relPath,
+		Owner:    owner,
+		Category: string(category),
+	}
 }
 
 func (collector *anyUsageCollector) inspectNode(node ast.Node, owner string) {

--- a/internal/validation/any_usage_test.go
+++ b/internal/validation/any_usage_test.go
@@ -22,6 +22,9 @@ const (
 	testValidateUsageErrFmt    = "validate usage: %v"
 	testNoViolationsErrFmt     = "expected no violations, got %v"
 	testFooTestPath            = "pkg/api/foo_test.go"
+	testOwnerPayload           = "Payload"
+	testOwnerUse               = "Use"
+	testSamplePath             = "sample.go"
 	testPayloadSource          = "package api\ntype Payload map[string]any\n"
 	testExpectedNormalizeRoots = "."
 )
@@ -97,6 +100,9 @@ func TestValidateAnyUsageDetectsViolation(t *testing.T) {
 	}
 	if violations[0].Line != 2 {
 		t.Fatalf("unexpected line: %d", violations[0].Line)
+	}
+	if got, want := violations[0].Identity, newFindingIdentity(testPayloadPath, testOwnerPayload, anyCategoryMapTypeValue); got != want {
+		t.Fatalf("unexpected identity: got %#v want %#v", got, want)
 	}
 }
 
@@ -381,6 +387,72 @@ label:
 	}
 }
 
+func TestValidateAnyUsageCarriesCanonicalFindingIdentity(t *testing.T) {
+	base := t.TempDir()
+	writeFile(t, apiPath(base, testPayloadFile), "package api\ntype Payload map[string]any\nfunc Use(value any) {\n\ttype Hidden = any\n\tvar local map[string]any\n\t_ = any(value)\n}\n")
+
+	violations, err := ValidateAnyUsage(AnyAllowlist{Version: 1}, base, []string{testRootAPI})
+	if err != nil {
+		t.Fatalf(testValidateUsageErrFmt, err)
+	}
+
+	got := make([]violationSummary, 0, len(violations))
+	for _, violation := range violations {
+		got = append(got, violationSummary{
+			file:     violation.Identity.File,
+			owner:    violation.Identity.Owner,
+			category: violation.Identity.Category,
+			line:     violation.Line,
+		})
+	}
+	want := []violationSummary{
+		{file: testPayloadPath, owner: testOwnerPayload, category: string(anyCategoryMapTypeValue), line: 2},
+		{file: testPayloadPath, owner: testOwnerUse, category: string(anyCategoryFieldType), line: 3},
+		{file: testPayloadPath, owner: testOwnerUse, category: string(anyCategoryTypeSpecType), line: 4},
+		{file: testPayloadPath, owner: testOwnerUse, category: string(anyCategoryMapTypeValue), line: 5},
+		{file: testPayloadPath, owner: testOwnerUse, category: string(anyCategoryCallExprFun), line: 6},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected violation identities:\ngot: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestAnyAllowlistIndexMatchesCanonicalFindingIdentity(t *testing.T) {
+	index := buildAllowlistIndex(AnyAllowlist{
+		Version: 1,
+		Entries: []AnyAllowlistEntry{
+			{
+				Path:        testPayloadPath,
+				Symbols:     []string{"Use"},
+				Description: "owner-wide allow",
+			},
+		},
+	})
+
+	if !index.isAllowed(newFindingIdentity(testPayloadPath, testOwnerUse, anyCategoryFieldType)) {
+		t.Fatalf("expected owner-wide allowlist match for field type")
+	}
+	if !index.isAllowed(newFindingIdentity(testPayloadPath, testOwnerUse, anyCategoryCallExprFun)) {
+		t.Fatalf("expected owner-wide allowlist match for call expression")
+	}
+	if index.isAllowed(newFindingIdentity(testPayloadPath, testOwnerPayload, anyCategoryMapTypeValue)) {
+		t.Fatalf("did not expect unrelated owner to match")
+	}
+
+	categoryScoped := anyAllowlistIndex{
+		allowAll: make(map[string]bool),
+		scoped: map[anyAllowlistSelector]struct{}{
+			{file: testPayloadPath, owner: testOwnerUse, category: string(anyCategoryCallExprFun)}: {},
+		},
+	}
+	if !categoryScoped.isAllowed(newFindingIdentity(testPayloadPath, testOwnerUse, anyCategoryCallExprFun)) {
+		t.Fatalf("expected category-scoped match")
+	}
+	if categoryScoped.isAllowed(newFindingIdentity(testPayloadPath, testOwnerUse, anyCategoryFieldType)) {
+		t.Fatalf("did not expect category-scoped selector to match a different category")
+	}
+}
+
 func TestValidateAnyUsageUsesEnclosingFunctionOwnerForLocalDeclarations(t *testing.T) {
 	base := t.TempDir()
 	writeFile(t, apiPath(base, testPayloadFile), "package api\nfunc Use() {\n\ttype Hidden = any\n\tvar local map[string]any\n\t_ = func(v any) {}\n}\n")
@@ -411,6 +483,13 @@ type usageSummary struct {
 	line     int
 }
 
+type violationSummary struct {
+	file     string
+	owner    string
+	category string
+	line     int
+}
+
 func collectUsageSummaries(t *testing.T, src string) []usageSummary {
 	t.Helper()
 
@@ -420,12 +499,12 @@ func collectUsageSummaries(t *testing.T, src string) []usageSummary {
 		t.Fatalf("parse file: %v", err)
 	}
 
-	usages := collectAnyUsages(file)
+	usages := collectAnyUsages(testSamplePath, file)
 	summaries := make([]usageSummary, 0, len(usages))
 	for _, usage := range usages {
 		summaries = append(summaries, usageSummary{
-			category: usage.category,
-			owner:    usage.owner,
+			category: anyUsageCategory(usage.identity.Category),
+			owner:    usage.identity.Owner,
 			line:     fset.Position(usage.pos).Line,
 		})
 	}


### PR DESCRIPTION
## Summary
This changes anyguard to carry a canonical finding identity derived at AST collection time. Each finding now retains normalized file identity, collected owner identity, and category, and allowlist matching consumes that identity directly instead of relying on positional association.

Resolves: #4 

## Changes
- add FindingIdentity to collected usages and reported violations
- route allowlist matching through canonical finding identity
- keep the current README owner contract intact while documenting category identity
- add tests for owner/category combinations, identity propagation, and category-scoped matching behavior

## Verification
- go test ./...
- golangci-lint run
- go test ./... -coverprofile=/tmp/anyguard_after.cover