### PR TITLE
fix(analyzer): fail closed on ambiguous file identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Finding identity:
 
 - File identity is the normalized repository-relative path used for allowlist matching and `Error.File`
 - Paths use slash separators and omit a leading `./`
+- Analyzer mode resolves file identity only from the configured or detected repository root
+- If a file does not resolve canonically under that repository root, analysis fails closed with an error
+- `anyguard` does not infer file identity from GOPATH layout, package import paths, or basename fallbacks
 - Owner identity is derived directly from the owning syntax node at collection time, not from positional or range overlap
 - `*ast.TypeSpec` uses the type name
 - `*ast.ValueSpec` uses the first declared name in source order
@@ -117,7 +120,7 @@ Failure semantics:
 - Allowlist read, parse, and validation errors halt analysis with an error
 - Stale, unresolved, malformed, or ambiguous allowlist selectors halt analysis with an error
 - Root resolution, filesystem traversal, and Go parse errors halt CLI validation with an error
-- Analyzer path resolution fails only after repository root, GOPATH, and package path derivation have all failed
+- Analyzer path resolution fails closed when a file cannot be mapped to a canonical repository-relative path under the repository root
 - Analyzer files with no filename or no token file are skipped
 - Changing the supported slots above requires an explicit README update because this section is the public compatibility contract
 

--- a/internal/validation/analyzer.go
+++ b/internal/validation/analyzer.go
@@ -25,7 +25,6 @@ const (
 	flagRepoRoot  = "repo-root"
 
 	errNoRootsProvided = "no roots provided for any usage validation"
-	goPathSrcSegment   = "/src/"
 )
 
 // NewAnalyzer constructs a go/analysis analyzer for any-usage validation.
@@ -176,11 +175,6 @@ func collectAnalyzerFiles(pass *analysis.Pass, repoRoot string, roots []string) 
 		return nil, errors.New("no usable roots after normalization")
 	}
 
-	pkgPath := ""
-	if pass.Pkg != nil {
-		pkgPath = pass.Pkg.Path()
-	}
-
 	files := make([]analyzerFile, 0, len(pass.Files))
 	for _, file := range pass.Files {
 		pos := pass.Fset.PositionFor(file.Package, false)
@@ -188,7 +182,7 @@ func collectAnalyzerFiles(pass *analysis.Pass, repoRoot string, roots []string) 
 			continue
 		}
 
-		relPath, err := relativePath(repoRoot, pos.Filename, pkgPath)
+		relPath, err := relativePath(repoRoot, pos.Filename)
 		if err != nil {
 			return nil, fmt.Errorf("compute relative path for %s: %w", pos.Filename, err)
 		}
@@ -209,35 +203,24 @@ func collectAnalyzerFiles(pass *analysis.Pass, repoRoot string, roots []string) 
 	return files, nil
 }
 
-func relativePath(repoRoot, absPath, pkgPath string) (string, error) {
+func relativePath(repoRoot, absPath string) (string, error) {
 	relPath, err := filepath.Rel(repoRoot, absPath)
-	if err == nil {
-		normalized := normalizePath(relPath)
-		if !isEscapingPath(normalized) {
-			return normalized, nil
-		}
+	if err != nil {
+		return "", fmt.Errorf("cannot establish canonical repository-relative path: %w", err)
 	}
-
-	if gopathRel, ok := pathFromGoPathSrc(absPath); ok {
-		return gopathRel, nil
+	normalized := normalizePath(relPath)
+	if normalized == "" || isEscapingPath(normalized) {
+		return "", fmt.Errorf(
+			"cannot establish canonical repository-relative path for %s under repo root %s",
+			filepath.Clean(absPath),
+			filepath.Clean(repoRoot),
+		)
 	}
-	if pkgPath == "" {
-		return "", errors.New("cannot resolve relative file path")
-	}
-	return normalizePath(filepath.Join(pkgPath, filepath.Base(absPath))), nil
+	return normalized, nil
 }
 
 func isEscapingPath(path string) bool {
 	return path == ".." || strings.HasPrefix(path, "../")
-}
-
-func pathFromGoPathSrc(absPath string) (string, bool) {
-	slash := filepath.ToSlash(absPath)
-	idx := strings.Index(slash, goPathSrcSegment)
-	if idx == -1 {
-		return "", false
-	}
-	return normalizePath(slash[idx+len(goPathSrcSegment):]), true
 }
 
 func normalizeConfiguredRoots(roots []string, repoRoot string) []string {

--- a/internal/validation/analyzer_test.go
+++ b/internal/validation/analyzer_test.go
@@ -6,6 +6,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"golang.org/x/tools/go/analysis"
@@ -19,6 +20,13 @@ const (
 	testPkgViolations  = "violations"
 	testPkgAllowed     = "allowed"
 	testPkgFiltered    = "filtered"
+	testPkgDir         = "pkg"
+	testNilPkgPath     = "pkg/nilpkg.go"
+	testAnalyzerSrc    = "package pkg\ntype T map[string]any\n"
+	testCreateSource   = "create source dir: %v"
+	testWriteSource    = "write source file: %v"
+	testParseSource    = "parse source: %v"
+	testUnexpectedErr  = "unexpected error: %v"
 )
 
 func TestAnalyzer(t *testing.T) {
@@ -47,18 +55,18 @@ func TestAnalyzerRespectsRoots(t *testing.T) {
 
 func TestCollectAnalyzerFilesWithNilPackage(t *testing.T) {
 	base := t.TempDir()
-	sourcePath := filepath.Join(base, "pkg", "nilpkg.go")
+	sourcePath := filepath.Join(base, testNilPkgPath)
 	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o750); err != nil {
-		t.Fatalf("create source dir: %v", err)
+		t.Fatalf(testCreateSource, err)
 	}
-	if err := os.WriteFile(sourcePath, []byte("package pkg\ntype T map[string]any\n"), 0o600); err != nil {
-		t.Fatalf("write source file: %v", err)
+	if err := os.WriteFile(sourcePath, []byte(testAnalyzerSrc), 0o600); err != nil {
+		t.Fatalf(testWriteSource, err)
 	}
 
 	fset := token.NewFileSet()
 	parsed, err := parser.ParseFile(fset, sourcePath, nil, parser.ParseComments)
 	if err != nil {
-		t.Fatalf("parse source: %v", err)
+		t.Fatalf(testParseSource, err)
 	}
 
 	pass := &analysis.Pass{
@@ -73,8 +81,39 @@ func TestCollectAnalyzerFilesWithNilPackage(t *testing.T) {
 	if len(files) != 1 {
 		t.Fatalf("expected one file, got %d", len(files))
 	}
-	if got, want := files[0].relPath, "pkg/nilpkg.go"; got != want {
+	if got, want := files[0].relPath, testNilPkgPath; got != want {
 		t.Fatalf("unexpected relative path: got %q want %q", got, want)
+	}
+}
+
+func TestCollectAnalyzerFilesRejectsAmbiguousIdentity(t *testing.T) {
+	repoRoot := t.TempDir()
+	gopathRoot := filepath.Join(t.TempDir(), "src", "example.com", "project")
+	sourcePath := filepath.Join(gopathRoot, testPkgDir, "outside.go")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o750); err != nil {
+		t.Fatalf(testCreateSource, err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(testAnalyzerSrc), 0o600); err != nil {
+		t.Fatalf(testWriteSource, err)
+	}
+
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, sourcePath, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf(testParseSource, err)
+	}
+
+	pass := &analysis.Pass{
+		Fset:  fset,
+		Files: []*ast.File{parsed},
+	}
+
+	_, err = collectAnalyzerFiles(pass, repoRoot, []string{DefaultRoots})
+	if err == nil {
+		t.Fatalf("expected canonical path resolution error")
+	}
+	if !strings.Contains(err.Error(), "cannot establish canonical repository-relative path") {
+		t.Fatalf(testUnexpectedErr, err)
 	}
 }
 

--- a/internal/validation/any_usage_test.go
+++ b/internal/validation/any_usage_test.go
@@ -73,7 +73,7 @@ func TestLoadAnyAllowlistRejectsLegacyEntryShape(t *testing.T) {
 		t.Fatalf("expected legacy entry shape error")
 	}
 	if !strings.Contains(err.Error(), "legacy allowlist entry shape is unsupported") {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf(testUnexpectedErrFmt, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Remove fallback path inference from the analyzer path so file identity is resolved only from a canonical repository-relative path.

Resolves: #6 

## Changes

- remove GOPATH and package-path fallback inference from analyzer file identity resolution
- fail closed when a file cannot be mapped under the configured or detected repo root
- add tests for canonical resolution success and ambiguous identity failure
- document the stricter analyzer failure semantics in the README

## Verification

- go test ./...
- golangci-lint run
- go test ./... -coverprofile=/tmp/anyguard-cover-after.out

## Notes

- total test coverage increased from 82.1% to 83.4%
- no depguard changes were required
