### PR TITLE
fix(validation): sort diagnostics deterministically

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Packages:
 - Exit `1`: analyzer/runtime/validation error.
 - Exit `2`: invalid CLI usage or flag parsing error.
 - On diagnostics, prints `file:line:column` and a reason.
+- Diagnostics are emitted deterministically sorted by `file`, `line`, `column`, `category`, and `owner`.
 
 ### Allowlist Schema
 

--- a/internal/validation/analyzer.go
+++ b/internal/validation/analyzer.go
@@ -52,9 +52,13 @@ type analyzerConfig struct {
 }
 
 type analyzerFile struct {
-	absPath   string
 	relPath   string
 	tokenFile *token.File
+}
+
+type analyzerViolation struct {
+	tokenFile *token.File
+	violation Error
 }
 
 type analysisResult struct{}
@@ -91,17 +95,7 @@ func (cfg *analyzerConfig) run(pass *analysis.Pass) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, file := range files {
-		if shouldExclude(file.relPath, allowlist.ExcludeGlobs) {
-			continue
-		}
-
-		violations, validateErr := validateAnyFile(file.absPath, file.relPath, index)
-		if validateErr != nil {
-			return nil, fmt.Errorf("validate %s: %w", file.relPath, validateErr)
-		}
-		reportViolations(pass, file.tokenFile, violations)
-	}
+	reportViolations(pass, collectAnalyzerViolations(files, findings, index))
 	return analysisResult{}, nil
 }
 
@@ -195,7 +189,6 @@ func collectAnalyzerFiles(pass *analysis.Pass, repoRoot string, roots []string) 
 			continue
 		}
 		files = append(files, analyzerFile{
-			absPath:   filepath.Clean(pos.Filename),
 			relPath:   relPath,
 			tokenFile: tokenFile,
 		})
@@ -278,25 +271,79 @@ func splitRoots(value string) []string {
 	return roots
 }
 
-func reportViolations(pass *analysis.Pass, file *token.File, violations []Error) {
+func collectAnalyzerViolations(files []analyzerFile, findings []collectedFinding, index anyAllowlistIndex) []analyzerViolation {
+	if len(files) == 0 || len(findings) == 0 {
+		return nil
+	}
+
+	tokenFilesByPath := make(map[string]*token.File, len(files))
+	filteredFindings := make([]collectedFinding, 0, len(findings))
+	for _, file := range files {
+		tokenFilesByPath[file.relPath] = file.tokenFile
+	}
+
+	for _, finding := range findings {
+		if _, ok := tokenFilesByPath[finding.identity.File]; !ok {
+			continue
+		}
+		filteredFindings = append(filteredFindings, finding)
+	}
+
+	violations := violationsFromFindings(filteredFindings, index)
+	reportable := make([]analyzerViolation, 0, len(violations))
+	for _, violation := range violations {
+		reportable = append(reportable, analyzerViolation{
+			tokenFile: tokenFilesByPath[violation.File],
+			violation: violation,
+		})
+	}
+	return reportable
+}
+
+func reportViolations(pass *analysis.Pass, violations []analyzerViolation) {
+	for _, reportable := range violations {
+		reportViolation(pass, reportable.tokenFile, reportable.violation)
+	}
+}
+
+func reportViolation(pass *analysis.Pass, file *token.File, violation Error) {
 	if file == nil {
 		return
 	}
-	for _, violation := range violations {
-		if violation.Line <= 0 || violation.Line > file.LineCount() {
-			continue
-		}
-		message := violation.Message
-		if violation.Code != "" {
-			message = message + " (code: " + violation.Code + ")"
-		}
-		pos := file.LineStart(violation.Line)
-		pass.Report(analysis.Diagnostic{
-			Pos:     pos,
-			End:     lineEnd(file, violation.Line, pos),
-			Message: message,
-		})
+
+	pos, ok := violationPos(file, violation.Line, violation.Column)
+	if !ok {
+		return
 	}
+
+	message := violation.Message
+	if violation.Code != "" {
+		message = message + " (code: " + violation.Code + ")"
+	}
+
+	pass.Report(analysis.Diagnostic{
+		Pos:     pos,
+		End:     lineEnd(file, violation.Line, pos),
+		Message: message,
+	})
+}
+
+func violationPos(file *token.File, line, column int) (token.Pos, bool) {
+	if line <= 0 || line > file.LineCount() {
+		return token.NoPos, false
+	}
+
+	start := file.LineStart(line)
+	if column <= 1 {
+		return start, true
+	}
+
+	pos := start + token.Pos(column-1)
+	end := lineEnd(file, line, start)
+	if pos > end {
+		return end, true
+	}
+	return pos, true
 }
 
 func lineEnd(file *token.File, line int, pos token.Pos) token.Pos {

--- a/internal/validation/analyzer_test.go
+++ b/internal/validation/analyzer_test.go
@@ -6,6 +6,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -117,9 +118,96 @@ func TestCollectAnalyzerFilesRejectsAmbiguousIdentity(t *testing.T) {
 	}
 }
 
+func TestCollectAnalyzerViolationsSortsAcrossFileOrder(t *testing.T) {
+	fset := token.NewFileSet()
+	alphaFile := parseAnalyzerTokenFile(t, fset, testAlphaPayloadPath, testAlphaPayloadSource)
+	zetaFile := parseAnalyzerTokenFile(t, fset, testZetaLaterPath, testZetaLaterSource)
+
+	files := []analyzerFile{
+		{relPath: testZetaLaterPath, tokenFile: zetaFile},
+		{relPath: testAlphaPayloadPath, tokenFile: alphaFile},
+	}
+	findings := []collectedFinding{
+		{identity: newFindingIdentity(testZetaLaterPath, testOwnerLater, anyCategoryCallExprFun), line: 2, column: 31},
+		{identity: newFindingIdentity(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeValue), line: 2, column: 22},
+		{identity: newFindingIdentity(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeKey), line: 2, column: 18},
+		{identity: newFindingIdentity(testZetaLaterPath, testOwnerLater, anyCategoryCallExprFun), line: 2, column: 23},
+	}
+
+	reportable := collectAnalyzerViolations(files, findings, anyAllowlistIndex{})
+	got := make([]violationSummary, 0, len(reportable))
+	for _, entry := range reportable {
+		got = append(got, violationSummary{
+			file:     entry.violation.Identity.File,
+			owner:    entry.violation.Identity.Owner,
+			category: entry.violation.Identity.Category,
+			line:     entry.violation.Line,
+			column:   entry.violation.Column,
+		})
+	}
+
+	want := []violationSummary{
+		{file: testAlphaPayloadPath, owner: testOwnerPayload, category: string(anyCategoryMapTypeKey), line: 2, column: 18},
+		{file: testAlphaPayloadPath, owner: testOwnerPayload, category: string(anyCategoryMapTypeValue), line: 2, column: 22},
+		{file: testZetaLaterPath, owner: testOwnerLater, category: string(anyCategoryCallExprFun), line: 2, column: 23},
+		{file: testZetaLaterPath, owner: testOwnerLater, category: string(anyCategoryCallExprFun), line: 2, column: 31},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected analyzer violation order:\ngot: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestReportViolationUsesLineAndColumn(t *testing.T) {
+	fset := token.NewFileSet()
+	tokenFile := parseAnalyzerTokenFile(t, fset, "pkg/report.go", "package pkg\nfunc Use() { _ = any(1) }\n")
+
+	var reported analysis.Diagnostic
+	pass := &analysis.Pass{
+		Fset: fset,
+		Report: func(diagnostic analysis.Diagnostic) {
+			reported = diagnostic
+		},
+	}
+
+	reportViolation(pass, tokenFile, Error{
+		File:    "pkg/report.go",
+		Line:    2,
+		Column:  18,
+		Message: "test diagnostic",
+		Identity: FindingIdentity{
+			File:     "pkg/report.go",
+			Owner:    "Use",
+			Category: string(anyCategoryCallExprFun),
+		},
+	})
+
+	if reported.Pos == token.NoPos {
+		t.Fatalf("expected reported diagnostic position")
+	}
+	position := fset.PositionFor(reported.Pos, false)
+	if position.Line != 2 || position.Column != 18 {
+		t.Fatalf("unexpected diagnostic position: line=%d column=%d", position.Line, position.Column)
+	}
+}
+
 func setAnalyzerFlag(t *testing.T, analyzer *analysis.Analyzer, key, value string) {
 	t.Helper()
 	if err := analyzer.Flags.Set(key, value); err != nil {
 		t.Fatalf("set %s: %v", key, err)
 	}
+}
+
+func parseAnalyzerTokenFile(t *testing.T, fset *token.FileSet, name, src string) *token.File {
+	t.Helper()
+
+	parsed, err := parser.ParseFile(fset, name, src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf(testParseSource, err)
+	}
+
+	tokenFile := fset.File(parsed.Package)
+	if tokenFile == nil {
+		t.Fatalf("expected token file for %s", name)
+	}
+	return tokenFile
 }

--- a/internal/validation/any_usage.go
+++ b/internal/validation/any_usage.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -32,6 +33,7 @@ var nolintDirectiveRE = regexp.MustCompile(`(?i)\bnolint(?::([a-z0-9_,-]+))?`)
 type Error struct {
 	File     string // File mirrors Identity.File for existing callers.
 	Line     int
+	Column   int
 	Message  string
 	Code     string
 	Identity FindingIdentity
@@ -129,14 +131,7 @@ func ValidateAnyUsage(allowlist AnyAllowlist, baseDir string, roots []string) ([
 		return nil, err
 	}
 
-	violations := make([]Error, 0, len(findings))
-	for _, finding := range findings {
-		if finding.suppressedByNolint || index.isAllowed(finding.identity) {
-			continue
-		}
-		violations = append(violations, newViolation(finding))
-	}
-	return violations, nil
+	return violationsFromFindings(findings, index), nil
 }
 
 func collectFindings(baseAbs string, roots, globs []string) ([]collectedFinding, error) {
@@ -345,25 +340,10 @@ func (index anyAllowlistIndex) isAllowed(identity FindingIdentity) bool {
 	return ok
 }
 
-func validateAnyFile(path, relPath string, index anyAllowlistIndex) ([]Error, error) {
-	findings, err := collectFileFindings(path, relPath)
-	if err != nil {
-		return nil, err
-	}
-
-	violations := make([]Error, 0, len(findings))
-	for _, finding := range findings {
-		if finding.suppressedByNolint || index.isAllowed(finding.identity) {
-			continue
-		}
-		violations = append(violations, newViolation(finding))
-	}
-	return violations, nil
-}
-
 type collectedFinding struct {
 	identity           FindingIdentity
 	line               int
+	column             int
 	code               string
 	suppressedByNolint bool
 }
@@ -394,6 +374,7 @@ func collectFileFindings(path, relPath string) ([]collectedFinding, error) {
 		findings = append(findings, collectedFinding{
 			identity:           usage.identity,
 			line:               pos.Line,
+			column:             pos.Column,
 			code:               lineCode(pos.Line, lines),
 			suppressedByNolint: isSuppressedByNolint(pos.Line, nolintLines),
 		})
@@ -413,10 +394,43 @@ func newViolation(finding collectedFinding) Error {
 	return Error{
 		File:     finding.identity.File,
 		Line:     finding.line,
+		Column:   finding.column,
 		Message:  "disallowed any usage. Add an allowlist entry, use //nolint:anyguard, or replace it with a concrete type",
 		Code:     finding.code,
 		Identity: finding.identity,
 	}
+}
+
+func violationsFromFindings(findings []collectedFinding, index anyAllowlistIndex) []Error {
+	violations := make([]Error, 0, len(findings))
+	for _, finding := range findings {
+		if finding.suppressedByNolint || index.isAllowed(finding.identity) {
+			continue
+		}
+		violations = append(violations, newViolation(finding))
+	}
+	sortViolations(violations)
+	return violations
+}
+
+func sortViolations(violations []Error) {
+	sort.Slice(violations, func(i, j int) bool {
+		left := violations[i]
+		right := violations[j]
+
+		switch {
+		case left.File != right.File:
+			return left.File < right.File
+		case left.Line != right.Line:
+			return left.Line < right.Line
+		case left.Column != right.Column:
+			return left.Column < right.Column
+		case left.Identity.Category != right.Identity.Category:
+			return left.Identity.Category < right.Identity.Category
+		default:
+			return left.Identity.Owner < right.Identity.Owner
+		}
+	})
 }
 
 func resolveAllowlistIndex(allowlist AnyAllowlist, findings []collectedFinding) (anyAllowlistIndex, error) {

--- a/internal/validation/any_usage_test.go
+++ b/internal/validation/any_usage_test.go
@@ -27,8 +27,13 @@ const (
 	testFooTestPath            = "pkg/api/foo_test.go"
 	testOwnerPayload           = "Payload"
 	testOwnerUse               = "Use"
+	testOwnerLater             = "Later"
 	testSamplePath             = "sample.go"
 	testPayloadSource          = "package api\ntype Payload map[string]any\n"
+	testAlphaPayloadPath       = "pkg/alpha/payload.go"
+	testAlphaPayloadSource     = "package alpha\ntype Payload map[any]any\n"
+	testZetaLaterPath          = "pkg/zeta/later.go"
+	testZetaLaterSource        = "package zeta\nfunc Later() { _, _ = any(1), any(2) }\n"
 	testExpectedNormalizeRoots = "."
 )
 
@@ -116,6 +121,9 @@ func TestValidateAnyUsageDetectsViolation(t *testing.T) {
 	}
 	if violations[0].Line != 2 {
 		t.Fatalf("unexpected line: %d", violations[0].Line)
+	}
+	if violations[0].Column != 25 {
+		t.Fatalf("unexpected column: %d", violations[0].Column)
 	}
 	if got, want := violations[0].Identity, newFindingIdentity(testPayloadPath, testOwnerPayload, anyCategoryMapTypeValue); got != want {
 		t.Fatalf("unexpected identity: got %#v want %#v", got, want)
@@ -513,17 +521,131 @@ func TestValidateAnyUsageCarriesCanonicalFindingIdentity(t *testing.T) {
 			owner:    violation.Identity.Owner,
 			category: violation.Identity.Category,
 			line:     violation.Line,
+			column:   violation.Column,
 		})
 	}
 	want := []violationSummary{
-		{file: testPayloadPath, owner: testOwnerPayload, category: string(anyCategoryMapTypeValue), line: 2},
-		{file: testPayloadPath, owner: testOwnerUse, category: string(anyCategoryFieldType), line: 3},
-		{file: testPayloadPath, owner: testOwnerUse, category: string(anyCategoryTypeSpecType), line: 4},
-		{file: testPayloadPath, owner: testOwnerUse, category: string(anyCategoryMapTypeValue), line: 5},
-		{file: testPayloadPath, owner: testOwnerUse, category: string(anyCategoryCallExprFun), line: 6},
+		{file: testPayloadPath, owner: testOwnerPayload, category: string(anyCategoryMapTypeValue), line: 2, column: 25},
+		{file: testPayloadPath, owner: testOwnerUse, category: string(anyCategoryFieldType), line: 3, column: 16},
+		{file: testPayloadPath, owner: testOwnerUse, category: string(anyCategoryTypeSpecType), line: 4, column: 16},
+		{file: testPayloadPath, owner: testOwnerUse, category: string(anyCategoryMapTypeValue), line: 5, column: 23},
+		{file: testPayloadPath, owner: testOwnerUse, category: string(anyCategoryCallExprFun), line: 6, column: 6},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected violation identities:\ngot: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestValidateAnyUsageSortsViolationsDeterministicallyAcrossRoots(t *testing.T) {
+	base := t.TempDir()
+	writeFile(t, filepath.Join(base, testZetaLaterPath), testZetaLaterSource)
+	writeFile(t, filepath.Join(base, testAlphaPayloadPath), testAlphaPayloadSource)
+
+	allowlist := AnyAllowlist{Version: anyAllowlistVersion}
+
+	gotReversed, err := ValidateAnyUsage(allowlist, base, []string{"pkg/zeta", "pkg/alpha"})
+	if err != nil {
+		t.Fatalf(testValidateUsageErrFmt, err)
+	}
+
+	gotCanonical, err := ValidateAnyUsage(allowlist, base, []string{"pkg/alpha", "pkg/zeta"})
+	if err != nil {
+		t.Fatalf(testValidateUsageErrFmt, err)
+	}
+
+	want := []violationSummary{
+		{file: testAlphaPayloadPath, owner: testOwnerPayload, category: string(anyCategoryMapTypeKey), line: 2, column: 18},
+		{file: testAlphaPayloadPath, owner: testOwnerPayload, category: string(anyCategoryMapTypeValue), line: 2, column: 22},
+		{file: testZetaLaterPath, owner: testOwnerLater, category: string(anyCategoryCallExprFun), line: 2, column: 23},
+		{file: testZetaLaterPath, owner: testOwnerLater, category: string(anyCategoryCallExprFun), line: 2, column: 31},
+	}
+
+	if got := collectViolationSummaries(gotReversed); !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected reversed-root ordering:\ngot: %#v\nwant: %#v", got, want)
+	}
+	if got := collectViolationSummaries(gotCanonical); !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected canonical-root ordering:\ngot: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestSortViolationsOrdersByFileLineColumnCategoryAndOwner(t *testing.T) {
+	violations := []Error{
+		{
+			File:   testZetaLaterPath,
+			Line:   1,
+			Column: 1,
+			Identity: FindingIdentity{
+				File:     testZetaLaterPath,
+				Owner:    testOwnerLater,
+				Category: string(anyCategoryCallExprFun),
+			},
+		},
+		{
+			File:   testAlphaPayloadPath,
+			Line:   2,
+			Column: 1,
+			Identity: FindingIdentity{
+				File:     testAlphaPayloadPath,
+				Owner:    testOwnerPayload,
+				Category: string(anyCategoryMapTypeValue),
+			},
+		},
+		{
+			File:   testAlphaPayloadPath,
+			Line:   1,
+			Column: 2,
+			Identity: FindingIdentity{
+				File:     testAlphaPayloadPath,
+				Owner:    "Beta",
+				Category: string(anyCategoryFieldType),
+			},
+		},
+		{
+			File:   testAlphaPayloadPath,
+			Line:   1,
+			Column: 1,
+			Identity: FindingIdentity{
+				File:     testAlphaPayloadPath,
+				Owner:    "Zulu",
+				Category: string(anyCategoryMapTypeValue),
+			},
+		},
+		{
+			File:   testAlphaPayloadPath,
+			Line:   1,
+			Column: 1,
+			Identity: FindingIdentity{
+				File:     testAlphaPayloadPath,
+				Owner:    "Alpha",
+				Category: string(anyCategoryMapTypeValue),
+			},
+		},
+		{
+			File:   testAlphaPayloadPath,
+			Line:   1,
+			Column: 1,
+			Identity: FindingIdentity{
+				File:     testAlphaPayloadPath,
+				Owner:    testOwnerPayload,
+				Category: string(anyCategoryMapTypeKey),
+			},
+		},
+	}
+
+	sortViolations(violations)
+
+	got := collectViolationSummaries(violations)
+	want := []violationSummary{
+		{file: testAlphaPayloadPath, owner: testOwnerPayload, category: string(anyCategoryMapTypeKey), line: 1, column: 1},
+		{file: testAlphaPayloadPath, owner: "Alpha", category: string(anyCategoryMapTypeValue), line: 1, column: 1},
+		{file: testAlphaPayloadPath, owner: "Zulu", category: string(anyCategoryMapTypeValue), line: 1, column: 1},
+		{file: testAlphaPayloadPath, owner: "Beta", category: string(anyCategoryFieldType), line: 1, column: 2},
+		{file: testAlphaPayloadPath, owner: testOwnerPayload, category: string(anyCategoryMapTypeValue), line: 2, column: 1},
+		{file: testZetaLaterPath, owner: testOwnerLater, category: string(anyCategoryCallExprFun), line: 1, column: 1},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected sorted violations:\ngot: %#v\nwant: %#v", got, want)
 	}
 }
 
@@ -579,6 +701,7 @@ type violationSummary struct {
 	owner    string
 	category string
 	line     int
+	column   int
 }
 
 func collectUsageSummaries(t *testing.T, src string) []usageSummary {
@@ -597,6 +720,20 @@ func collectUsageSummaries(t *testing.T, src string) []usageSummary {
 			category: anyUsageCategory(usage.identity.Category),
 			owner:    usage.identity.Owner,
 			line:     fset.Position(usage.pos).Line,
+		})
+	}
+	return summaries
+}
+
+func collectViolationSummaries(violations []Error) []violationSummary {
+	summaries := make([]violationSummary, 0, len(violations))
+	for _, violation := range violations {
+		summaries = append(summaries, violationSummary{
+			file:     violation.Identity.File,
+			owner:    violation.Identity.Owner,
+			category: violation.Identity.Category,
+			line:     violation.Line,
+			column:   violation.Column,
 		})
 	}
 	return summaries


### PR DESCRIPTION
## Summary

- sort diagnostics deterministically by `file`, `line`, `column`, `category`, and `owner`
- carry column metadata through validation and use it for analyzer report positions
- add tests covering stable ordering across root/file order differences and analyzer reporting

Resolves: #7  

## Testing

- `go test ./...`
- `golangci-lint run`
- `go build ./...`
- `go test -race -v ./...`
- `go test -bench=. -run=^$ ./...`
- `bash ./scripts/ci/build-custom-gcl.sh`
- `bash ./scripts/ci/run-golangci-plugin-smoke.sh`

## Notes

- aggregate coverage improved from `83.4%` to `84.6%`