### PR TITLE
test: add corpus matrix for analyzer behavior and allowlist hygiene

### DIFF
--- a/internal/validation/corpus_test.go
+++ b/internal/validation/corpus_test.go
@@ -1,0 +1,216 @@
+package validation
+
+import (
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const (
+	corpusFixtureSupported          = "supported"
+	corpusFixtureBoundary           = "boundary"
+	corpusFixtureUnsupported        = "unsupported"
+	corpusFixtureAllowlistHygiene   = "allowlist-hygiene"
+	corpusFixtureStabilityBase      = "stability/base"
+	corpusFixtureStabilityCanonical = "stability/canonical"
+)
+
+func TestValidateAnyUsageCorpusSupportedMatrix(t *testing.T) {
+	t.Run("disallowed", func(t *testing.T) {
+		got := collectViolationSummaries(mustValidateCorpus(t, corpusFixtureSupported, testAllowlistEmpty, []string{DefaultRoots}))
+		want := []violationSummary{
+			{file: "pkg/api/supported.go", owner: "FieldTypeDisallowed", category: string(anyCategoryFieldType), line: 3, column: 28},
+			{file: "pkg/api/supported.go", owner: "ValueSpecDisallowed", category: string(anyCategoryValueSpecType), line: 5, column: 25},
+			{file: "pkg/api/supported.go", owner: "TypeSpecDisallowed", category: string(anyCategoryTypeSpecType), line: 7, column: 27},
+			{file: "pkg/api/supported.go", owner: "ArrayTypeDisallowed", category: string(anyCategoryArrayTypeElt), line: 9, column: 28},
+			{file: "pkg/api/supported.go", owner: "MapKeyDisallowed", category: string(anyCategoryMapTypeKey), line: 11, column: 27},
+			{file: "pkg/api/supported.go", owner: "MapValueDisallowed", category: string(anyCategoryMapTypeValue), line: 13, column: 36},
+			{file: "pkg/api/supported.go", owner: "ChanTypeDisallowed", category: string(anyCategoryChanTypeValue), line: 15, column: 33},
+			{file: "pkg/api/supported.go", owner: "StarTypeDisallowed", category: string(anyCategoryStarExprX), line: 17, column: 26},
+			{file: "pkg/api/supported.go", owner: "EllipsisDisallowed", category: string(anyCategoryEllipsisElt), line: 19, column: 35},
+			{file: "pkg/api/supported.go", owner: "TypeAssertDisallowed", category: string(anyCategoryTypeAssertType), line: 22, column: 13},
+			{file: "pkg/api/supported.go", owner: "CallExprDisallowed", category: string(anyCategoryCallExprFun), line: 26, column: 6},
+			{file: "pkg/api/supported.go", owner: "IndexExprDisallowed", category: string(anyCategoryIndexExprIndex), line: 30, column: 13},
+			{file: "pkg/api/supported.go", owner: "IndexListDisallowed", category: string(anyCategoryIndexListIndex), line: 36, column: 15},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("unexpected supported corpus violations:\ngot: %#v\nwant: %#v", got, want)
+		}
+	})
+
+	t.Run("allowed", func(t *testing.T) {
+		violations := mustValidateCorpus(t, corpusFixtureSupported, "allowlist-all.yaml", []string{DefaultRoots})
+		if len(violations) != 0 {
+			t.Fatalf("expected supported allowlist corpus to be clean, got %v", violations)
+		}
+	})
+
+	t.Run(corpusFixtureBoundary, func(t *testing.T) {
+		got := collectViolationSummaries(mustValidateCorpus(t, corpusFixtureBoundary, testAllowlistEmpty, []string{DefaultRoots}))
+		want := []violationSummary{
+			{file: "pkg/api/boundary.go", owner: "NestedArray", category: string(anyCategoryArrayTypeElt), line: 3, column: 31},
+			{file: "pkg/api/boundary.go", owner: "NestedMap", category: string(anyCategoryMapTypeValue), line: 5, column: 29},
+			{file: "pkg/api/boundary.go", owner: "Boundary", category: string(anyCategoryArrayTypeElt), line: 7, column: 27},
+			{file: "pkg/api/boundary.go", owner: "Boundary", category: string(anyCategoryArrayTypeElt), line: 7, column: 45},
+			{file: "pkg/api/boundary.go", owner: "Boundary", category: string(anyCategoryMapTypeKey), line: 8, column: 18},
+			{file: "pkg/api/boundary.go", owner: "Boundary", category: string(anyCategoryArrayTypeElt), line: 9, column: 28},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("unexpected boundary corpus violations:\ngot: %#v\nwant: %#v", got, want)
+		}
+	})
+}
+
+func TestValidateAnyUsageCorpusUnsupportedContexts(t *testing.T) {
+	violations := mustValidateCorpus(t, corpusFixtureUnsupported, testAllowlistEmpty, []string{DefaultRoots})
+	if len(violations) != 0 {
+		t.Fatalf("expected unsupported corpus to remain unreported, got %v", violations)
+	}
+}
+
+func TestValidateAnyUsageCorpusStability(t *testing.T) {
+	base := collectViolationSummaries(mustValidateCorpus(t, corpusFixtureStabilityBase, testAllowlistEmpty, []string{"pkg/alpha", "pkg/zeta"}))
+	want := []violationSummary{
+		{file: "pkg/alpha/payload.go", owner: "Payload", category: string(anyCategoryMapTypeKey), line: 3, column: 18},
+		{file: "pkg/alpha/payload.go", owner: "Payload", category: string(anyCategoryMapTypeValue), line: 3, column: 22},
+		{file: "pkg/zeta/later.go", owner: "Later", category: string(anyCategoryCallExprFun), line: 3, column: 23},
+		{file: "pkg/zeta/later.go", owner: "Later", category: string(anyCategoryCallExprFun), line: 3, column: 31},
+	}
+	if !reflect.DeepEqual(base, want) {
+		t.Fatalf("unexpected base stability corpus violations:\ngot: %#v\nwant: %#v", base, want)
+	}
+
+	t.Run("file order changes", func(t *testing.T) {
+		reversed := collectViolationSummaries(mustValidateCorpus(t, corpusFixtureStabilityBase, testAllowlistEmpty, []string{"pkg/zeta", "pkg/alpha"}))
+		if !reflect.DeepEqual(reversed, base) {
+			t.Fatalf("expected identical results across root order changes:\ngot: %#v\nwant: %#v", reversed, base)
+		}
+	})
+
+	t.Run("declaration order changes", func(t *testing.T) {
+		got := collectIdentitySummaries(mustValidateCorpus(t, "stability/declaration-order", testAllowlistEmpty, []string{DefaultRoots}))
+		wantIdentities := collectIdentitySummaries(mustValidateCorpus(t, corpusFixtureStabilityCanonical, testAllowlistEmpty, []string{DefaultRoots}))
+		if !reflect.DeepEqual(got, wantIdentities) {
+			t.Fatalf("expected identical finding identities across declaration order changes:\ngot: %#v\nwant: %#v", got, wantIdentities)
+		}
+	})
+
+	t.Run("irrelevant comments", func(t *testing.T) {
+		got := collectViolationSummaries(mustValidateCorpus(t, "stability/comments", testAllowlistEmpty, []string{DefaultRoots}))
+		wantCanonical := collectViolationSummaries(mustValidateCorpus(t, corpusFixtureStabilityCanonical, testAllowlistEmpty, []string{DefaultRoots}))
+		if !reflect.DeepEqual(got, wantCanonical) {
+			t.Fatalf("expected identical results across comment noise:\ngot: %#v\nwant: %#v", got, wantCanonical)
+		}
+	})
+
+	t.Run("formatting noise", func(t *testing.T) {
+		got := collectViolationSummaries(mustValidateCorpus(t, "stability/formatting", testAllowlistEmpty, []string{DefaultRoots}))
+		wantCanonical := collectViolationSummaries(mustValidateCorpus(t, corpusFixtureStabilityCanonical, testAllowlistEmpty, []string{DefaultRoots}))
+		if !reflect.DeepEqual(got, wantCanonical) {
+			t.Fatalf("expected identical results across formatting noise:\ngot: %#v\nwant: %#v", got, wantCanonical)
+		}
+	})
+}
+
+func TestValidateAnyUsageCorpusAllowlistHygiene(t *testing.T) {
+	testCases := []struct {
+		name        string
+		allowlist   string
+		wantMessage string
+	}{
+		{
+			name:        "stale selector",
+			allowlist:   "allowlist-stale.yaml",
+			wantMessage: "does not match any finding",
+		},
+		{
+			name:        "typoed category",
+			allowlist:   "allowlist-typo-category.yaml",
+			wantMessage: "unknown category",
+		},
+		{
+			name:        "typoed symbol",
+			allowlist:   "allowlist-typo-owner.yaml",
+			wantMessage: "does not match any finding",
+		},
+		{
+			name:        "malformed selector",
+			allowlist:   "allowlist-malformed.yaml",
+			wantMessage: "selector missing owner",
+		},
+		{
+			name:        "unresolved selector",
+			allowlist:   "allowlist-unresolved.yaml",
+			wantMessage: "does not match any finding",
+		},
+		{
+			name:        "overbroad allow",
+			allowlist:   "allowlist-overbroad.yaml",
+			wantMessage: "legacy allowlist entry shape is unsupported",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := ValidateAnyUsageFromFile(
+				filepath.Join(corpusFixtureDir(t, corpusFixtureAllowlistHygiene), testCase.allowlist),
+				corpusFixtureDir(t, corpusFixtureAllowlistHygiene),
+				[]string{DefaultRoots},
+			)
+			if err == nil {
+				t.Fatalf("expected config error for %s", testCase.allowlist)
+			}
+			if !strings.Contains(err.Error(), testCase.wantMessage) {
+				t.Fatalf("unexpected config error: %v", err)
+			}
+		})
+	}
+}
+
+type identitySummary struct {
+	file     string
+	owner    string
+	category string
+}
+
+func mustValidateCorpus(t *testing.T, fixture, allowlist string, roots []string) []Error {
+	t.Helper()
+
+	base := corpusFixtureDir(t, fixture)
+	violations, err := ValidateAnyUsageFromFile(filepath.Join(base, allowlist), base, roots)
+	if err != nil {
+		t.Fatalf("validate corpus %s: %v", fixture, err)
+	}
+	return violations
+}
+
+func corpusFixtureDir(t *testing.T, fixture string) string {
+	t.Helper()
+	return filepath.Join("testdata", "corpus", fixture)
+}
+
+func collectIdentitySummaries(violations []Error) []identitySummary {
+	summaries := make([]identitySummary, 0, len(violations))
+	for _, violation := range violations {
+		summaries = append(summaries, identitySummary{
+			file:     violation.Identity.File,
+			owner:    violation.Identity.Owner,
+			category: violation.Identity.Category,
+		})
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		left := summaries[i]
+		right := summaries[j]
+		switch {
+		case left.file != right.file:
+			return left.file < right.file
+		case left.owner != right.owner:
+			return left.owner < right.owner
+		default:
+			return left.category < right.category
+		}
+	})
+	return summaries
+}

--- a/internal/validation/testdata/corpus/allowlist-hygiene/allowlist-malformed.yaml
+++ b/internal/validation/testdata/corpus/allowlist-hygiene/allowlist-malformed.yaml
@@ -1,0 +1,5 @@
+version: 2
+entries:
+  - selector:
+      path: pkg/api/payload.go
+    description: malformed selector

--- a/internal/validation/testdata/corpus/allowlist-hygiene/allowlist-overbroad.yaml
+++ b/internal/validation/testdata/corpus/allowlist-hygiene/allowlist-overbroad.yaml
@@ -1,0 +1,6 @@
+version: 2
+entries:
+  - path: pkg/api/payload.go
+    symbols:
+      - Payload
+    description: unsupported broad allow

--- a/internal/validation/testdata/corpus/allowlist-hygiene/allowlist-stale.yaml
+++ b/internal/validation/testdata/corpus/allowlist-hygiene/allowlist-stale.yaml
@@ -1,0 +1,7 @@
+version: 2
+entries:
+  - selector:
+      path: pkg/api/payload.go
+      owner: Payload
+      category: "*ast.MapType.Key"
+    description: stale selector after source changed

--- a/internal/validation/testdata/corpus/allowlist-hygiene/allowlist-typo-category.yaml
+++ b/internal/validation/testdata/corpus/allowlist-hygiene/allowlist-typo-category.yaml
@@ -1,0 +1,7 @@
+version: 2
+entries:
+  - selector:
+      path: pkg/api/payload.go
+      owner: Payload
+      category: "*ast.MapTyp.Value"
+    description: typoed category

--- a/internal/validation/testdata/corpus/allowlist-hygiene/allowlist-typo-owner.yaml
+++ b/internal/validation/testdata/corpus/allowlist-hygiene/allowlist-typo-owner.yaml
@@ -1,0 +1,7 @@
+version: 2
+entries:
+  - selector:
+      path: pkg/api/payload.go
+      owner: Paylod
+      category: "*ast.MapType.Value"
+    description: typoed owner symbol

--- a/internal/validation/testdata/corpus/allowlist-hygiene/allowlist-unresolved.yaml
+++ b/internal/validation/testdata/corpus/allowlist-hygiene/allowlist-unresolved.yaml
@@ -1,0 +1,7 @@
+version: 2
+entries:
+  - selector:
+      path: pkg/api/missing.go
+      owner: Payload
+      category: "*ast.MapType.Value"
+    description: unresolved selector

--- a/internal/validation/testdata/corpus/allowlist-hygiene/pkg/api/payload.go
+++ b/internal/validation/testdata/corpus/allowlist-hygiene/pkg/api/payload.go
@@ -1,0 +1,3 @@
+package api
+
+type Payload map[string]any

--- a/internal/validation/testdata/corpus/boundary/allowlist-empty.yaml
+++ b/internal/validation/testdata/corpus/boundary/allowlist-empty.yaml
@@ -1,0 +1,2 @@
+version: 2
+entries: []

--- a/internal/validation/testdata/corpus/boundary/pkg/api/boundary.go
+++ b/internal/validation/testdata/corpus/boundary/pkg/api/boundary.go
@@ -1,0 +1,12 @@
+package api
+
+type NestedArray map[string][]any
+
+type NestedMap []map[string]any
+
+func Boundary(values ...[]any) map[string][]any {
+	var typed []map[any]string
+	type Local = map[string][]any
+	_ = typed
+	return nil
+}

--- a/internal/validation/testdata/corpus/stability/base/allowlist-empty.yaml
+++ b/internal/validation/testdata/corpus/stability/base/allowlist-empty.yaml
@@ -1,0 +1,2 @@
+version: 2
+entries: []

--- a/internal/validation/testdata/corpus/stability/base/pkg/alpha/payload.go
+++ b/internal/validation/testdata/corpus/stability/base/pkg/alpha/payload.go
@@ -1,0 +1,3 @@
+package alpha
+
+type Payload map[any]any

--- a/internal/validation/testdata/corpus/stability/base/pkg/zeta/later.go
+++ b/internal/validation/testdata/corpus/stability/base/pkg/zeta/later.go
@@ -1,0 +1,3 @@
+package zeta
+
+func Later() { _, _ = any(1), any(2) }

--- a/internal/validation/testdata/corpus/stability/canonical/allowlist-empty.yaml
+++ b/internal/validation/testdata/corpus/stability/canonical/allowlist-empty.yaml
@@ -1,0 +1,2 @@
+version: 2
+entries: []

--- a/internal/validation/testdata/corpus/stability/canonical/pkg/api/stability.go
+++ b/internal/validation/testdata/corpus/stability/canonical/pkg/api/stability.go
@@ -1,0 +1,5 @@
+package api
+
+type Payload map[any]any
+
+func Later() { _, _ = any(1), any(2) }

--- a/internal/validation/testdata/corpus/stability/comments/allowlist-empty.yaml
+++ b/internal/validation/testdata/corpus/stability/comments/allowlist-empty.yaml
@@ -1,0 +1,2 @@
+version: 2
+entries: []

--- a/internal/validation/testdata/corpus/stability/comments/pkg/api/stability.go
+++ b/internal/validation/testdata/corpus/stability/comments/pkg/api/stability.go
@@ -1,0 +1,5 @@
+package api
+
+type Payload map[any]any // comment noise
+
+func Later() { _, _ = any(1), any(2) } // comment noise

--- a/internal/validation/testdata/corpus/stability/declaration-order/allowlist-empty.yaml
+++ b/internal/validation/testdata/corpus/stability/declaration-order/allowlist-empty.yaml
@@ -1,0 +1,2 @@
+version: 2
+entries: []

--- a/internal/validation/testdata/corpus/stability/declaration-order/pkg/api/stability.go
+++ b/internal/validation/testdata/corpus/stability/declaration-order/pkg/api/stability.go
@@ -1,0 +1,5 @@
+package api
+
+func Later() { _, _ = any(1), any(2) }
+
+type Payload map[any]any

--- a/internal/validation/testdata/corpus/stability/formatting/allowlist-empty.yaml
+++ b/internal/validation/testdata/corpus/stability/formatting/allowlist-empty.yaml
@@ -1,0 +1,2 @@
+version: 2
+entries: []

--- a/internal/validation/testdata/corpus/stability/formatting/pkg/api/stability.go
+++ b/internal/validation/testdata/corpus/stability/formatting/pkg/api/stability.go
@@ -1,0 +1,5 @@
+package api
+
+type Payload map[any]any   
+
+func Later() { _, _ = any(1), any(2) }   

--- a/internal/validation/testdata/corpus/supported/allowlist-all.yaml
+++ b/internal/validation/testdata/corpus/supported/allowlist-all.yaml
@@ -1,0 +1,67 @@
+version: 2
+entries:
+  - selector:
+      path: pkg/api/supported.go
+      owner: FieldTypeDisallowed
+      category: "*ast.Field.Type"
+    description: allow parameter field type
+  - selector:
+      path: pkg/api/supported.go
+      owner: ValueSpecDisallowed
+      category: "*ast.ValueSpec.Type"
+    description: allow value spec type
+  - selector:
+      path: pkg/api/supported.go
+      owner: TypeSpecDisallowed
+      category: "*ast.TypeSpec.Type"
+    description: allow type alias
+  - selector:
+      path: pkg/api/supported.go
+      owner: ArrayTypeDisallowed
+      category: "*ast.ArrayType.Elt"
+    description: allow array element type
+  - selector:
+      path: pkg/api/supported.go
+      owner: MapKeyDisallowed
+      category: "*ast.MapType.Key"
+    description: allow map key type
+  - selector:
+      path: pkg/api/supported.go
+      owner: MapValueDisallowed
+      category: "*ast.MapType.Value"
+    description: allow map value type
+  - selector:
+      path: pkg/api/supported.go
+      owner: ChanTypeDisallowed
+      category: "*ast.ChanType.Value"
+    description: allow channel element type
+  - selector:
+      path: pkg/api/supported.go
+      owner: StarTypeDisallowed
+      category: "*ast.StarExpr.X"
+    description: allow pointer target type
+  - selector:
+      path: pkg/api/supported.go
+      owner: EllipsisDisallowed
+      category: "*ast.Ellipsis.Elt"
+    description: allow variadic element type
+  - selector:
+      path: pkg/api/supported.go
+      owner: TypeAssertDisallowed
+      category: "*ast.TypeAssertExpr.Type"
+    description: allow type assertion target
+  - selector:
+      path: pkg/api/supported.go
+      owner: CallExprDisallowed
+      category: "*ast.CallExpr.Fun"
+    description: allow syntax-only any call
+  - selector:
+      path: pkg/api/supported.go
+      owner: IndexExprDisallowed
+      category: "*ast.IndexExpr.Index"
+    description: allow syntax-only any index
+  - selector:
+      path: pkg/api/supported.go
+      owner: IndexListDisallowed
+      category: "*ast.IndexListExpr.Indices"
+    description: allow syntax-only any index list

--- a/internal/validation/testdata/corpus/supported/allowlist-empty.yaml
+++ b/internal/validation/testdata/corpus/supported/allowlist-empty.yaml
@@ -1,0 +1,2 @@
+version: 2
+entries: []

--- a/internal/validation/testdata/corpus/supported/pkg/api/supported.go
+++ b/internal/validation/testdata/corpus/supported/pkg/api/supported.go
@@ -1,0 +1,37 @@
+package api
+
+func FieldTypeDisallowed(v any) {}
+
+var ValueSpecDisallowed any
+
+type TypeSpecDisallowed = any
+
+type ArrayTypeDisallowed []any
+
+type MapKeyDisallowed map[any]string
+
+type MapValueDisallowed map[string]any
+
+func ChanTypeDisallowed(ch chan any) {}
+
+type StarTypeDisallowed *any
+
+func EllipsisDisallowed(values ...any) {}
+
+func TypeAssertDisallowed(value interface{}) {
+	_ = value.(any)
+}
+
+func CallExprDisallowed() {
+	_ = any(1)
+}
+
+func IndexExprDisallowed(values map[int]int, any int) {
+	_ = values[any]
+}
+
+type Box[T, U any] struct{}
+
+func IndexListDisallowed() {
+	_ = Box[int, any]{}
+}

--- a/internal/validation/testdata/corpus/unsupported/allowlist-empty.yaml
+++ b/internal/validation/testdata/corpus/unsupported/allowlist-empty.yaml
@@ -1,0 +1,2 @@
+version: 2
+entries: []

--- a/internal/validation/testdata/corpus/unsupported/pkg/api/unsupported.go
+++ b/internal/validation/testdata/corpus/unsupported/pkg/api/unsupported.go
@@ -1,0 +1,17 @@
+package api
+
+type Box[T any] struct{}
+
+func Constraint[T any](value T) {
+	any := 1
+	_ = any
+	_ = []int{any}
+	_ = map[int]int{any: any}
+	switch value.(type) {
+	case any:
+	}
+}
+
+const text = "any in a string should stay quiet"
+
+// any in a comment should stay quiet.


### PR DESCRIPTION
## Summary

Add a corpus-style analyzer test matrix covering:
- every supported syntax category with disallowed and allowlisted cases
- nested boundary cases
- unsupported and ambiguous contexts that must remain unreported or fail closed
- stability scenarios for file/root order, declaration order, comments, and formatting noise
- allowlist hygiene failures for stale, typoed, malformed, unresolved, and overbroad config

Resolves: #8 

## Testing

- go build -v ./...
- go test ./...
- go test -race -v ./...
- go test -bench=. -run=^$ ./...
- golangci-lint run
- bash ./scripts/ci/run-golangci-plugin-smoke.sh

## Notes

- `internal/validation` coverage increased from `84.4%` to `84.7%`
