### PR TITLE
docs: add upstream readiness notes for golangci-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Each entry must provide an exact `selector` with the canonical `{path, owner, ca
 
 Nested `any` is reportable only when the nested identifier still appears in one of those slots. For example, `map[string][]any` reports because the innermost `any` is the `Elt` of an `*ast.ArrayType`.
 
-Unsupported and ambiguous cases:
+#### Unsupported and ambiguous cases
 
 - Type parameter constraints such as `func Use[T any](v T) {}` and `type Box[T any] struct{}`
 - In those examples, `any` constrains `T`. It is not a concrete type position like `func Use(v any) {}` or `type Value = any`
@@ -99,7 +99,7 @@ Unsupported and ambiguous cases:
 - Example false positive, `Box[int, any]` style syntax reports because the second slot matches `*ast.IndexListExpr.Indices[i]`
 - These syntax-only matches can be suppressed with an exact allowlist selector or with `//nolint:anyguard` on the same line or the previous line
 
-Finding identity:
+#### Finding identity
 
 - File identity is the normalized repository-relative path used for allowlist matching and `Error.File`
 - Paths use slash separators and omit a leading `./`
@@ -116,7 +116,7 @@ Finding identity:
 - Owner or category are never inferred during allowlist matching
 - A selector that does not resolve to a current finding is treated as a configuration error
 
-Failure semantics:
+#### Failure semantics
 
 - Allowlist read, parse, and validation errors halt analysis with an error
 - Stale, unresolved, malformed, or ambiguous allowlist selectors halt analysis with an error
@@ -144,6 +144,7 @@ golangci-lint run
 - Stable plugin import path: `github.com/tobythehutt/anyguard/plugin`
 - Plugin name in `.golangci.yml`: `anyguard`
 - Integration docs and examples: `docs/golangci-lint/README.md`
+- Upstream readiness notes: `docs/golangci-lint/README.md#upstream-readiness`
 
 #### core integration
 

--- a/docs/golangci-lint/README.md
+++ b/docs/golangci-lint/README.md
@@ -46,6 +46,21 @@ linters:
 - `roots` (string or list): roots to analyze. Default is `./...`.
 - `repo-root` (string): optional repository root override for path resolution.
 
+## Upstream readiness
+
+For maintainers evaluating possible core inclusion:
+
+- The normative spec is the root [`Detection Contract`](../../README.md#detection-contract), [`Allowlist Schema`](../../README.md#allowlist-schema), and [`Behavior`](../../README.md#behavior).
+- Supported syntax categories are exactly the AST child slots enumerated in the detection contract. Anything outside that list is out of scope and intentionally silent.
+- Each finding has one exact identity: `{path, owner, category}`. Allowlist matching is exact on that identity only.
+- The analyzer fails closed on unresolved file identity, allowlist parse/validation errors, stale or ambiguous selectors, and traversal or parse failures.
+- Reporting is deterministic: syntax only, no type info, no scoring, no heuristic ranking, and stable sort order by `file`, `line`, `column`, `category`, and `owner`.
+- The false-positive boundary is explicit in the detection contract. The syntax-only `CallExpr` and index-form matches are documented there and are suppressible with an exact allowlist selector or `//nolint:anyguard`.
+- Allowlist strictness is deliberate in schema version `2`: no broad file-level or owner-only exceptions, no duplicate selectors, and no selectors that fail to resolve to a current finding.
+- Non-goals: type-parameter constraints, broader unsafe-dynamic-use detection, or claims that every finding is a bug or security issue.
+- Adjacent linters such as `forbidigo`, `depguard`, `asasalint`, and `ireturn` cover different scopes: identifier bans, import policy, a variadic-call bug pattern, and interface-return style. `anyguard` governs only concrete `any` usage in the documented syntax slots.
+- The right framing is policy linter, not detector. It enforces an explicit repository policy over `any`; upstream inclusion is still not guaranteed.
+
 ## Run
 
 ```bash


### PR DESCRIPTION
## Summary
- add a short upstream-readiness section to `docs/golangci-lint/README.md`
- point that section at the existing detection contract, allowlist schema, and behavior docs
- add linkable subheadings in the root README and link the readiness section from the golangci-lint integration notes

Resolves: #9 

## Testing
- go test ./...
- go test -race -v ./...
- go test -bench=. -run=^$ ./...
- golangci-lint run
- bash ./scripts/ci/build-custom-gcl.sh
- bash ./scripts/ci/run-golangci-plugin-smoke.sh