### PR TITLE
fix: guarantee deterministic ordering across anyguard outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Packages:
 - Exit `1`: analyzer/runtime/validation error.
 - Exit `2`: invalid CLI usage or flag parsing error.
 - On diagnostics, prints `file:line:column` and a reason.
-- Diagnostics are emitted deterministically sorted by `file`, `line`, `column`, `category`, and `owner`.
+- CLI, analyzer, and golangci-lint plugin diagnostics are a compatibility guarantee: they are emitted deterministically in `file`, `line`, `column`, `category`, `owner` order, independent of root order, filesystem traversal, map iteration, formatting noise, and irrelevant comments.
 
 ### Allowlist Schema
 
@@ -143,6 +143,7 @@ golangci-lint run
 
 - Stable plugin import path: `github.com/tobythehutt/anyguard/plugin`
 - Plugin name in `.golangci.yml`: `anyguard`
+- Plugin diagnostics follow the same deterministic ordering contract as the CLI and public analyzer.
 - Integration docs and examples: `docs/golangci-lint/README.md`
 - Upstream readiness notes: `docs/golangci-lint/README.md#upstream-readiness`
 
@@ -152,6 +153,7 @@ For direct integration into `golangci-lint`, import the public analyzer entrypoi
 
 - Module path: `github.com/tobythehutt/anyguard`
 - Analyzer constructor: `anyguard.NewAnalyzer()`
+- Analyzer diagnostics follow the same deterministic ordering contract as the CLI and module plugin.
 
 ### License
 

--- a/docs/golangci-lint/README.md
+++ b/docs/golangci-lint/README.md
@@ -5,6 +5,7 @@
 - Module path: `github.com/tobythehutt/anyguard`
 - Plugin import path: `github.com/tobythehutt/anyguard/plugin`
 - Linter name in `.golangci.yml`: `anyguard`
+- Module-plugin diagnostics follow the same deterministic ordering compatibility guarantee as the CLI and public analyzer.
 
 ## Build a custom golangci-lint
 
@@ -54,7 +55,8 @@ For maintainers evaluating possible core inclusion:
 - Supported syntax categories are exactly the AST child slots enumerated in the detection contract. Anything outside that list is out of scope and intentionally silent.
 - Each finding has one exact identity: `{path, owner, category}`. Allowlist matching is exact on that identity only.
 - The analyzer fails closed on unresolved file identity, allowlist parse/validation errors, stale or ambiguous selectors, and traversal or parse failures.
-- Reporting is deterministic: syntax only, no type info, no scoring, no heuristic ranking, and stable sort order by `file`, `line`, `column`, `category`, and `owner`.
+- CLI, analyzer, and module-plugin reporting order is a compatibility guarantee: syntax only, no type info, no scoring, no heuristic ranking, and stable sort order by `file`, `line`, `column`, `category`, and `owner`.
+- Ordering does not depend on configured root order, filesystem traversal order, or map iteration.
 - The false-positive boundary is explicit in the detection contract. The syntax-only `CallExpr` and index-form matches are documented there and are suppressible with an exact allowlist selector or `//nolint:anyguard`.
 - Allowlist strictness is deliberate in schema version `2`: no broad file-level or owner-only exceptions, no duplicate selectors, and no selectors that fail to resolve to a current finding.
 - Non-goals: type-parameter constraints, broader unsafe-dynamic-use detection, or claims that every finding is a bug or security issue.

--- a/internal/validation/any_usage.go
+++ b/internal/validation/any_usage.go
@@ -151,6 +151,7 @@ func collectFindings(baseAbs string, roots, globs []string) ([]collectedFinding,
 		}
 		findings = append(findings, rootFindings...)
 	}
+	sortCollectedFindings(findings)
 	return findings, nil
 }
 
@@ -411,6 +412,30 @@ func violationsFromFindings(findings []collectedFinding, index anyAllowlistIndex
 	}
 	sortViolations(violations)
 	return violations
+}
+
+func sortCollectedFindings(findings []collectedFinding) {
+	sort.Slice(findings, func(i, j int) bool {
+		left := findings[i]
+		right := findings[j]
+
+		switch {
+		case left.identity.File != right.identity.File:
+			return left.identity.File < right.identity.File
+		case left.line != right.line:
+			return left.line < right.line
+		case left.column != right.column:
+			return left.column < right.column
+		case left.identity.Category != right.identity.Category:
+			return left.identity.Category < right.identity.Category
+		case left.identity.Owner != right.identity.Owner:
+			return left.identity.Owner < right.identity.Owner
+		case left.code != right.code:
+			return left.code < right.code
+		default:
+			return !left.suppressedByNolint && right.suppressedByNolint
+		}
+	})
 }
 
 func sortViolations(violations []Error) {

--- a/internal/validation/any_usage_test.go
+++ b/internal/validation/any_usage_test.go
@@ -28,6 +28,9 @@ const (
 	testOwnerPayload           = "Payload"
 	testOwnerUse               = "Use"
 	testOwnerLater             = "Later"
+	testOwnerAlpha             = "Alpha"
+	testOwnerBeta              = "Beta"
+	testOwnerZulu              = "Zulu"
 	testSamplePath             = "sample.go"
 	testPayloadSource          = "package api\ntype Payload map[string]any\n"
 	testAlphaPayloadPath       = "pkg/alpha/payload.go"
@@ -568,6 +571,36 @@ func TestValidateAnyUsageSortsViolationsDeterministicallyAcrossRoots(t *testing.
 	}
 }
 
+func TestCollectFindingsSortsDeterministicallyAcrossRoots(t *testing.T) {
+	base := t.TempDir()
+	writeFile(t, filepath.Join(base, testZetaLaterPath), testZetaLaterSource)
+	writeFile(t, filepath.Join(base, testAlphaPayloadPath), testAlphaPayloadSource)
+
+	gotReversed, err := collectFindings(base, []string{"pkg/zeta", "pkg/alpha"}, nil)
+	if err != nil {
+		t.Fatalf("collect findings reversed roots: %v", err)
+	}
+
+	gotCanonical, err := collectFindings(base, []string{"pkg/alpha", "pkg/zeta"}, nil)
+	if err != nil {
+		t.Fatalf("collect findings canonical roots: %v", err)
+	}
+
+	want := []violationSummary{
+		{file: testAlphaPayloadPath, owner: testOwnerPayload, category: string(anyCategoryMapTypeKey), line: 2, column: 18},
+		{file: testAlphaPayloadPath, owner: testOwnerPayload, category: string(anyCategoryMapTypeValue), line: 2, column: 22},
+		{file: testZetaLaterPath, owner: testOwnerLater, category: string(anyCategoryCallExprFun), line: 2, column: 23},
+		{file: testZetaLaterPath, owner: testOwnerLater, category: string(anyCategoryCallExprFun), line: 2, column: 31},
+	}
+
+	if got := collectFindingSummaries(gotReversed); !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected reversed-root finding order:\ngot: %#v\nwant: %#v", got, want)
+	}
+	if got := collectFindingSummaries(gotCanonical); !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected canonical-root finding order:\ngot: %#v\nwant: %#v", got, want)
+	}
+}
+
 func TestSortViolationsOrdersByFileLineColumnCategoryAndOwner(t *testing.T) {
 	violations := []Error{
 		{
@@ -646,6 +679,49 @@ func TestSortViolationsOrdersByFileLineColumnCategoryAndOwner(t *testing.T) {
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected sorted violations:\ngot: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestSortCollectedFindingsOrdersByFileLineColumnCategoryOwnerCodeAndSuppression(t *testing.T) {
+	const (
+		testCodeLater     = "later"
+		testCodeValueLate = "value-late"
+		testCodeBeta      = "beta"
+		testCodeZulu      = "zulu"
+		testCodeAlpha     = "alpha"
+		testCodeKey       = "key"
+		testCodeAAA       = "aaa"
+		testCodeBBB       = "bbb"
+	)
+
+	findings := []collectedFinding{
+		testCollectedFinding(testZetaLaterPath, testOwnerLater, anyCategoryCallExprFun, 1, 1, testCodeLater, false),
+		testCollectedFinding(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeValue, 2, 1, testCodeValueLate, false),
+		testCollectedFinding(testAlphaPayloadPath, testOwnerBeta, anyCategoryFieldType, 1, 2, testCodeBeta, false),
+		testCollectedFinding(testAlphaPayloadPath, testOwnerZulu, anyCategoryMapTypeValue, 1, 1, testCodeZulu, false),
+		testCollectedFinding(testAlphaPayloadPath, testOwnerAlpha, anyCategoryMapTypeValue, 1, 1, testCodeAlpha, false),
+		testCollectedFinding(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeKey, 1, 1, testCodeKey, false),
+		testCollectedFinding(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeValue, 1, 1, testCodeAAA, false),
+		testCollectedFinding(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeValue, 1, 1, testCodeBBB, false),
+		testCollectedFinding(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeValue, 1, 1, testCodeBBB, true),
+	}
+
+	sortCollectedFindings(findings)
+
+	want := []collectedFinding{
+		testCollectedFinding(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeKey, 1, 1, testCodeKey, false),
+		testCollectedFinding(testAlphaPayloadPath, testOwnerAlpha, anyCategoryMapTypeValue, 1, 1, testCodeAlpha, false),
+		testCollectedFinding(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeValue, 1, 1, testCodeAAA, false),
+		testCollectedFinding(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeValue, 1, 1, testCodeBBB, false),
+		testCollectedFinding(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeValue, 1, 1, testCodeBBB, true),
+		testCollectedFinding(testAlphaPayloadPath, testOwnerZulu, anyCategoryMapTypeValue, 1, 1, testCodeZulu, false),
+		testCollectedFinding(testAlphaPayloadPath, testOwnerBeta, anyCategoryFieldType, 1, 2, testCodeBeta, false),
+		testCollectedFinding(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeValue, 2, 1, testCodeValueLate, false),
+		testCollectedFinding(testZetaLaterPath, testOwnerLater, anyCategoryCallExprFun, 1, 1, testCodeLater, false),
+	}
+
+	if !reflect.DeepEqual(findings, want) {
+		t.Fatalf("unexpected sorted findings:\ngot: %#v\nwant: %#v", findings, want)
 	}
 }
 
@@ -737,6 +813,36 @@ func collectViolationSummaries(violations []Error) []violationSummary {
 		})
 	}
 	return summaries
+}
+
+func collectFindingSummaries(findings []collectedFinding) []violationSummary {
+	summaries := make([]violationSummary, 0, len(findings))
+	for _, finding := range findings {
+		summaries = append(summaries, violationSummary{
+			file:     finding.identity.File,
+			owner:    finding.identity.Owner,
+			category: finding.identity.Category,
+			line:     finding.line,
+			column:   finding.column,
+		})
+	}
+	return summaries
+}
+
+func testCollectedFinding(
+	path, owner string,
+	category anyUsageCategory,
+	line, column int,
+	code string,
+	suppressed bool,
+) collectedFinding {
+	return collectedFinding{
+		identity:           newFindingIdentity(path, owner, category),
+		line:               line,
+		column:             column,
+		code:               code,
+		suppressedByNolint: suppressed,
+	}
 }
 
 func writeAllowlist(t *testing.T, path string, allowlist AnyAllowlist) {

--- a/scripts/ci/run-golangci-plugin-smoke.sh
+++ b/scripts/ci/run-golangci-plugin-smoke.sh
@@ -43,8 +43,15 @@ if [[ "${status}" -eq 0 ]]; then
 	exit 1
 fi
 
-if ! grep -q "pkg/bad/bad.go" "${output_file}"; then
-	echo "expected diagnostic for pkg/bad/bad.go"
+expected_locations=$'pkg/alpha/payload.go:3:14\npkg/alpha/payload.go:4:23\npkg/bad/bad.go:3:25\npkg/zeta/later.go:4:6\npkg/zeta/later.go:5:6'
+actual_locations="$(grep -oE 'pkg/[^:]+:[0-9]+:[0-9]+' "${output_file}" || true)"
+
+if [[ "${actual_locations}" != "${expected_locations}" ]]; then
+	echo "unexpected diagnostic order from module plugin smoke run"
+	echo "got:"
+	printf '%s\n' "${actual_locations}"
+	echo "want:"
+	printf '%s\n' "${expected_locations}"
 	exit 1
 fi
 

--- a/testdata/golangci/smoke/pkg/alpha/payload.go
+++ b/testdata/golangci/smoke/pkg/alpha/payload.go
@@ -1,0 +1,4 @@
+package alpha
+
+type Key map[any]string
+type Value map[string]any

--- a/testdata/golangci/smoke/pkg/zeta/later.go
+++ b/testdata/golangci/smoke/pkg/zeta/later.go
@@ -1,0 +1,6 @@
+package zeta
+
+func Later() {
+	_ = any(1)
+	_ = any(2)
+}


### PR DESCRIPTION
## Summary
- document deterministic ordering as a compatibility guarantee for CLI, analyzer, and module-plugin output
- sort collected findings before allowlist resolution/reporting so output order cannot drift with root traversal
- add regression coverage for root-order stability and collected-finding sorting
- tighten the golangci module-plugin smoke test to assert emitted diagnostic order

Resolves: #17 

## Testing
- go build -v ./...
- go test ./...
- go test -race -v ./...
- go test -bench=. -run=^$ ./...
- golangci-lint run
- bash ./scripts/ci/run-golangci-plugin-smoke.sh

## Notes
- coverage improved from 84.9% to 85.2%
