### PR TITLE
docs: clarify how anyguard differs from generic ban-pattern linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ Packages:
 - On diagnostics, prints `file:line:column` and a reason.
 - CLI, analyzer, and golangci-lint plugin diagnostics are a compatibility guarantee: they are emitted deterministically in `file`, `line`, `column`, `category`, `owner` order, independent of root order, filesystem traversal, map iteration, formatting noise, and irrelevant comments.
 
+### Comparison With Generic Ban-Pattern Linters
+
+`anyguard` overlaps with generic identifier or pattern ban linters in one narrow way: both can help enforce "do not use `any` here" policy. If that is the whole requirement, a generic ban-pattern linter is simpler.
+
+`anyguard` exists for the narrower case where `any` is allowed at a few explicit boundaries and those exceptions must stay exact, current, and reviewable.
+
+| Concern | Generic ban-pattern linter | `anyguard` |
+| --- | --- | --- |
+| Basic overlap | Usually bans an identifier, token, or textual pattern and reports matches. | Reports concrete `any` usage too, but only when the identifier resolves semantically to the universe alias in the supported AST slots. |
+| Allowlist precision | Exceptions are often broad file, symbol, regex, or inline suppression patterns. | Each exception must match one exact selector: `{path, owner, category}`. Broad file-level or owner-only exceptions are not supported in schema version `2`. |
+| Stale selector rejection | Suppressions can drift silently after refactors or when the original finding disappears. | Selectors that no longer resolve to a current finding are rejected as stale or typoed configuration. |
+| Canonical finding identity | Findings are often tied to textual matches or positions only. | Each finding has one canonical identity captured as `{path, owner, category}`, and diagnostics are emitted in deterministic order. |
+| Configuration hygiene | Config validation is often looser because the tool's job is just pattern matching. | Unknown, malformed, duplicate, ambiguous, and unresolved selectors are rejected and analysis fails closed. |
+| Detection contract | Supported and unsupported cases are often implicit in the matcher. | The README defines the exact supported AST parent/child slots and explicitly documents unsupported and ambiguous cases as part of the public contract. |
+
+The practical answer to "why not use an existing ban-pattern linter?" is:
+
+- Use a generic ban-pattern linter when the policy is simply "match and ban `any`."
+- Use `anyguard` when the policy is "allow only these exact `any` boundary usages, reject stale exceptions, and keep a stable contract for what counts as a finding."
+
 ### Allowlist Schema
 
 The allowlist is strict configuration. The current schema version is `2`.

--- a/docs/golangci-lint/README.md
+++ b/docs/golangci-lint/README.md
@@ -51,7 +51,7 @@ linters:
 
 For maintainers evaluating possible core inclusion:
 
-- The normative spec is the root [`Detection Contract`](../../README.md#detection-contract), [`Allowlist Schema`](../../README.md#allowlist-schema), and [`Behavior`](../../README.md#behavior).
+- The normative spec is the root [`Behavior`](../../README.md#behavior), [`Comparison With Generic Ban-Pattern Linters`](../../README.md#comparison-with-generic-ban-pattern-linters), [`Allowlist Schema`](../../README.md#allowlist-schema), and [`Detection Contract`](../../README.md#detection-contract).
 - Supported syntax categories are exactly the AST child slots enumerated in the detection contract. Anything outside that list is out of scope and intentionally silent.
 - Each finding has one exact identity: `{path, owner, category}`. Allowlist matching is exact on that identity only.
 - The analyzer fails closed on unresolved file identity, allowlist parse/validation errors, stale or ambiguous selectors, and traversal or parse failures.
@@ -60,7 +60,7 @@ For maintainers evaluating possible core inclusion:
 - The false-positive boundary is explicit in the detection contract. Ambiguous `CallExpr` and index-form slots are checked with type info, so shadowed identifiers like `func any(int)`, `values[any]` with a local variable, or `type any interface{}; Box[int, any]{}` stay silent.
 - Allowlist strictness is deliberate in schema version `2`: no broad file-level or owner-only exceptions, no duplicate selectors, and no selectors that fail to resolve to a current finding.
 - Non-goals: type-parameter constraints, broader unsafe-dynamic-use detection, or claims that every finding is a bug or security issue.
-- Adjacent linters such as `forbidigo`, `depguard`, `asasalint`, and `ireturn` cover different scopes: identifier bans, import policy, a variadic-call bug pattern, and interface-return style. `anyguard` governs only concrete `any` usage in the documented syntax slots.
+- The root comparison section is the canonical answer to "why not just use an existing ban-pattern linter?": overlap exists at the policy level, but `anyguard` is specifically about exact exceptions, stale-selector rejection, and a documented syntax-slot contract.
 - The right framing is policy linter, not detector. It enforces an explicit repository policy over `any`; upstream inclusion is still not guaranteed.
 
 ## Run


### PR DESCRIPTION
## Summary

- add a README comparison table explaining where `anyguard` overlaps with generic ban-pattern linters and where it is intentionally different
- document the specific differentiators reviewers asked about: exact `{path, owner, category}` selectors, stale selector rejection, canonical finding identity, fail-closed configuration hygiene, and the supported/unsupported AST-slot contract
- consolidate golangci-lint upstream-readiness notes so the root README is the canonical answer to “why not use an existing ban-pattern linter?”

Resolves: #19 