### PR TITLE
test: add explicit corpus coverage for any boundary cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Each entry must provide an exact `selector` with the canonical `{path, owner, ca
 
 `anyguard` is slot driven. It only reports `any` when the identifier is the direct child of one of the AST slots below and resolves semantically to the Go universe `any` alias. Anything not listed is unsupported and is not detected or reported (you are welcome to contribute).
 
+The syntax snippets in this section are mirrored in the corpus fixtures under `internal/validation/testdata/corpus/{supported,boundary,unsupported}` so the documented boundary stays testable.
+
 | Parent AST node | Child slot | Supported syntax |
 | --- | --- | --- |
 | `*ast.Field` | `Type` | Parameter types, result types, struct field types, and interface field or member types |
@@ -105,15 +107,13 @@ Each entry must provide an exact `selector` with the canonical `{path, owner, ca
 | `*ast.IndexExpr` | `Index` | Single-argument instantiations such as `Box[any]` when the index resolves to the universe alias |
 | `*ast.IndexListExpr` | `Indices[i]` | Multi-argument instantiations such as `Box[int, any]` when the type argument resolves to the universe alias |
 
-Nested `any` is reportable only when the nested identifier still appears in one of those slots. For example, `map[string][]any` reports because the innermost `any` is the `Elt` of an `*ast.ArrayType`.
+Nested `any` is reportable only when the nested identifier still appears in one of those slots. For example, `type NestedArray map[string][]any` reports because the innermost `any` is still the `Elt` of an `*ast.ArrayType`.
 
 #### Unsupported and ambiguous cases
 
-- Type parameter constraints such as `func Use[T any](v T) {}` and `type Box[T any] struct{}`
-- In those examples, `any` constrains `T`. It is not a concrete type position like `func Use(v any) {}` or `type Value = any`
-- Any `any` occurrence whose direct parent child AST relationship is not listed above
-- Identifier names, selectors, assignments, composite literal elements, return expressions, type switch case lists, comments, and string literals
-- Each report requires semantic resolution to the universe `any` alias. Shadowed declarations such as `func any(v int)`, `values[any]` with a local index variable, or `type any interface{}; Box[int, any]{}` stay silent.
+- Type parameter constraints stay silent because `any` constrains a type parameter instead of occupying a concrete supported slot, for example `func Use[T any](value T) {}`.
+- Any `any` occurrence whose direct parent child AST relationship is not listed above stays silent. That includes identifier names, selectors, assignments, composite literal elements, return expressions, type switch case lists, comments, and string literals; for example `func TypeSwitchCaseList(value interface{}) { switch value.(type) { case any, string: } }`.
+- Each report requires semantic resolution to the universe `any` alias. Shadowed declarations stay silent, for example `func any(v int) int` with `any(1)`, `func Use(values []int) int { any := 0; return values[any] }`, or `type any interface{}; Box[int, any]{}`.
 - On invalid or incomplete code, `anyguard` does not guess from bare syntax. It only reports when the identifier can still be resolved as the universe alias.
 - Exact allowlist selectors and `//nolint:anyguard` remain the escape hatches when a resolved universe-`any` usage is intentionally allowed
 

--- a/internal/validation/any_usage_test.go
+++ b/internal/validation/any_usage_test.go
@@ -492,6 +492,69 @@ func Use() {
 	}
 }
 
+func TestCollectAnyUsagesIgnoresUnsupportedPositions(t *testing.T) {
+	src := `package p
+
+func Use[T any](value T) {
+	_ = value
+}
+
+type Box[T any] struct {
+	Value T
+}
+
+func TypeSwitchCaseList(value interface{}) {
+	switch value.(type) {
+	case any, string:
+	}
+}
+
+func IdentifierNamedAny(any int) int {
+	holder := struct{ any int }{any: any}
+	_ = []int{any}
+	_ = map[int]int{any: any}
+
+	slot := 0
+	slot = any
+
+	_ = holder.any
+	return any + slot
+}
+
+const text = "any in a string should stay quiet"
+
+// any in a comment should stay quiet.
+`
+
+	got := collectUsageSummaries(t, src)
+	if len(got) != 0 {
+		t.Fatalf("expected unsupported positions to stay quiet, got %#v", got)
+	}
+}
+
+func TestCollectAnyUsagesIgnoresShadowedFunctionAndIndexVariable(t *testing.T) {
+	src := `package p
+
+func any(v int) int {
+	return v
+}
+
+func ShadowedCall() {
+	_ = any(1)
+}
+
+func ShadowedIndex(values []int) int {
+	any := 0
+	return values[any]
+}
+`
+
+	got := collectUsageSummaries(t, src)
+	if len(got) != 0 {
+		t.Fatalf("expected shadowed function and index variable to stay quiet, got %#v", got)
+	}
+}
+
 func TestCollectAnyUsagesTraversesSupportedSlotsInStatements(t *testing.T) {
 	src := `package p
 

--- a/internal/validation/corpus_test.go
+++ b/internal/validation/corpus_test.go
@@ -64,9 +64,9 @@ func TestValidateAnyUsageCorpusSupportedMatrix(t *testing.T) {
 }
 
 func TestValidateAnyUsageCorpusUnsupportedContexts(t *testing.T) {
-	violations := mustValidateCorpus(t, corpusFixtureUnsupported, testAllowlistEmpty, []string{DefaultRoots})
-	if len(violations) != 0 {
-		t.Fatalf("expected unsupported corpus to remain unreported, got %v", violations)
+	got := collectViolationSummaries(mustValidateCorpus(t, corpusFixtureUnsupported, testAllowlistEmpty, []string{DefaultRoots}))
+	if len(got) != 0 {
+		t.Fatalf("expected unsupported corpus to remain unreported, got %#v", got)
 	}
 }
 

--- a/internal/validation/testdata/corpus/unsupported/pkg/api/unsupported.go
+++ b/internal/validation/testdata/corpus/unsupported/pkg/api/unsupported.go
@@ -1,15 +1,29 @@
 package api
 
-type Box[T any] struct{}
+func Use[T any](value T) {
+	_ = value
+}
 
-func Constraint[T any](value T) {
-	any := 1
-	_ = any
+type Box[T any] struct {
+	Value T
+}
+
+func TypeSwitchCaseList(value interface{}) {
+	switch value.(type) {
+	case any, string:
+	}
+}
+
+func IdentifierNamedAny(any int) int {
+	holder := struct{ any int }{any: any}
 	_ = []int{any}
 	_ = map[int]int{any: any}
-	switch value.(type) {
-	case any:
-	}
+
+	slot := 0
+	slot = any
+
+	_ = holder.any
+	return any + slot
 }
 
 const text = "any in a string should stay quiet"

--- a/internal/validation/testdata/corpus/unsupported/pkg/shadowedcall/shadowed_call.go
+++ b/internal/validation/testdata/corpus/unsupported/pkg/shadowedcall/shadowed_call.go
@@ -1,0 +1,9 @@
+package shadowedcall
+
+func any(v int) int {
+	return v
+}
+
+func Use() {
+	_ = any(1)
+}

--- a/internal/validation/testdata/corpus/unsupported/pkg/shadowedindex/shadowed_index.go
+++ b/internal/validation/testdata/corpus/unsupported/pkg/shadowedindex/shadowed_index.go
@@ -1,0 +1,6 @@
+package shadowedindex
+
+func Use(values []int) int {
+	any := 0
+	return values[any]
+}

--- a/internal/validation/testdata/corpus/unsupported/pkg/shadowedtype/shadowed_type.go
+++ b/internal/validation/testdata/corpus/unsupported/pkg/shadowedtype/shadowed_type.go
@@ -1,0 +1,9 @@
+package shadowedtype
+
+type any interface{}
+
+type Box[T, U any] struct{}
+
+func Use() {
+	_ = Box[int, any]{}
+}


### PR DESCRIPTION
## Summary
- add explicit unsupported corpus fixtures for generic constraints, type switch case lists, comments and strings, composite literal elements, assignments, and shadowed `any` call/index/type cases
- add focused collector tests for unsupported positions and shadowed function/index boundaries

Resolves: #20 

## Testing
- go test ./...
- go test -race -v ./...
- go test -bench=. -run=^$ ./...
- go build -v ./...
- golangci-lint run
- bash ./scripts/ci/run-golangci-plugin-smoke.sh
