### PR TITLE
docs(readme): align anyguard summary with AST-slot contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Packages:
 ### Behavior
 
 - Scans `.go` files under configured roots.
-- Parses AST, resolves identifiers semantically, and reports supported-slot usage of the universe `any` alias.
+- `anyguard` is AST-slot-driven with limited semantic checking: it reports `any` only in explicitly supported AST child slots.
+- That supported-slot list is the public contract. Findings still require the identifier to resolve to the Go universe `any` alias, which keeps shadowed declarations silent.
+- `anyguard` is not a full type-position semantic classifier. Reviewers using a stricter type-position-only rule may treat supported-slot cases such as `any(1)`, `Single[any]{}`, and `Box[int, any]{}` as false positives, but they remain reportable by contract.
 - Compares findings against an allowlist.
 - Supports strict selector-based exceptions, exclude globs, and specific `//nolint` instructions.
 - Exception metadata is minimal. `description` is required.
@@ -49,7 +51,7 @@ Packages:
 
 | Concern | Generic ban-pattern linter | `anyguard` |
 | --- | --- | --- |
-| Basic overlap | Usually bans an identifier, token, or textual pattern and reports matches. | Reports concrete `any` usage too, but only when the identifier resolves semantically to the universe alias in the supported AST slots. |
+| Basic overlap | Usually bans an identifier, token, or textual pattern and reports matches. | Reports `any` only in explicitly supported AST child slots. It also resolves the universe `any` alias so shadowed declarations stay silent. It is not a full type-position semantic classifier, so supported-slot cases such as `any(1)`, `Single[any]{}`, and `Box[int, any]{}` remain reportable by contract. |
 | Allowlist precision | Exceptions are often broad file, symbol, regex, or inline suppression patterns. | Each exception must match one exact selector: `{path, owner, category}`. Broad file-level or owner-only exceptions are not supported in schema version `2`. |
 | Stale selector rejection | Suppressions can drift silently after refactors or when the original finding disappears. | Selectors that no longer resolve to a current finding are rejected as stale or typoed configuration. |
 | Canonical finding identity | Findings are often tied to textual matches or positions only. | Each finding has one canonical identity captured as `{path, owner, category}`, and diagnostics are emitted in deterministic order. |
@@ -88,7 +90,7 @@ Each entry must provide an exact `selector` with the canonical `{path, owner, ca
 
 ### Detection Contract
 
-`anyguard` is slot driven. It only reports `any` when the identifier is the direct child of one of the AST slots below and resolves semantically to the Go universe `any` alias. Anything not listed is unsupported and is not detected or reported (you are welcome to contribute).
+`anyguard` is AST-slot driven. It only reports `any` when the identifier is the direct child of one of the AST slots below, and that supported-slot list is the public contract. Reports also require limited semantic checking: the identifier must resolve to the Go universe `any` alias, which keeps shadowed declarations silent. `anyguard` does not attempt a broader type-position semantic classifier, so supported-slot cases such as `any(1)`, `Single[any]{}`, and `Box[int, any]{}` remain reportable by contract. Anything not listed is unsupported and is not detected or reported (you are welcome to contribute).
 
 The syntax snippets in this section are mirrored in the corpus fixtures under `internal/validation/testdata/corpus/{supported,boundary,unsupported}` so the documented boundary stays testable.
 
@@ -106,6 +108,8 @@ The syntax snippets in this section are mirrored in the corpus fixtures under `i
 | `*ast.CallExpr` | `Fun` | Conversions such as `any(value)` when the callee resolves to the universe alias |
 | `*ast.IndexExpr` | `Index` | Single-argument instantiations such as `Box[any]` when the index resolves to the universe alias |
 | `*ast.IndexListExpr` | `Indices[i]` | Multi-argument instantiations such as `Box[int, any]` when the type argument resolves to the universe alias |
+
+`*ast.CallExpr.Fun`, `*ast.IndexExpr.Index`, and `*ast.IndexListExpr.Indices[i]` are deliberate supported-slot checks. They still resolve the universe `any` alias to suppress shadowed declarations, but cases such as `any(1)`, `Single[any]{}`, and `Box[int, any]{}` remain reportable even though a stricter type-position-only rule might exclude them.
 
 Nested `any` is reportable only when the nested identifier still appears in one of those slots. For example, `type NestedArray map[string][]any` reports because the innermost `any` is still the `Elt` of an `*ast.ArrayType`.
 

--- a/docs/golangci-lint/README.md
+++ b/docs/golangci-lint/README.md
@@ -6,6 +6,9 @@
 - Plugin import path: `github.com/tobythehutt/anyguard/plugin`
 - Linter name in `.golangci.yml`: `anyguard`
 - Module-plugin diagnostics follow the same deterministic ordering compatibility guarantee as the CLI and public analyzer.
+- The plugin uses the same AST-slot-driven contract as the CLI and public analyzer.
+- It reports `any` only in explicitly supported AST child slots and resolves the universe `any` alias to suppress shadowed declarations.
+- It is not a full type-position semantic classifier, so supported-slot cases such as `any(1)`, `Single[any]{}`, and `Box[int, any]{}` remain reportable by contract.
 
 ## Build a custom golangci-lint
 
@@ -52,12 +55,12 @@ linters:
 For maintainers evaluating possible core inclusion:
 
 - The normative spec is the root [`Behavior`](../../README.md#behavior), [`Comparison With Generic Ban-Pattern Linters`](../../README.md#comparison-with-generic-ban-pattern-linters), [`Allowlist Schema`](../../README.md#allowlist-schema), and [`Detection Contract`](../../README.md#detection-contract).
-- Supported syntax categories are exactly the AST child slots enumerated in the detection contract. Anything outside that list is out of scope and intentionally silent.
+- Supported syntax categories are exactly the AST child slots enumerated in the detection contract. The contract is AST-slot-driven with universe-`any` alias resolution. Anything outside that list is out of scope and intentionally silent.
 - Each finding has one exact identity: `{path, owner, category}`. Allowlist matching is exact on that identity only.
 - The analyzer fails closed on unresolved file identity, allowlist parse/validation errors, stale or ambiguous selectors, and traversal or parse failures.
-- CLI, analyzer, and module-plugin reporting order is a compatibility guarantee: slot-based matching with semantic resolution of the universe `any` alias, no scoring, no heuristic ranking, and stable sort order by `file`, `line`, `column`, `category`, and `owner`.
+- CLI, analyzer, and module-plugin reporting order is a compatibility guarantee: no scoring, no heuristic ranking, and stable sort order by `file`, `line`, `column`, `category`, and `owner`.
 - Ordering does not depend on configured root order, filesystem traversal order, or map iteration.
-- The false-positive boundary is explicit in the detection contract. Ambiguous `CallExpr` and index-form slots are checked with type info, so shadowed identifiers like `func any(int)`, `values[any]` with a local variable, or `type any interface{}; Box[int, any]{}` stay silent.
+- The false-positive boundary is explicit in the detection contract. `*ast.CallExpr.Fun`, `*ast.IndexExpr.Index`, and `*ast.IndexListExpr.Indices[i]` still resolve the universe `any` alias to suppress shadowed declarations, but cases such as `any(1)`, `Single[any]{}`, and `Box[int, any]{}` remain reportable because those slots are supported by contract.
 - Allowlist strictness is deliberate in schema version `2`: no broad file-level or owner-only exceptions, no duplicate selectors, and no selectors that fail to resolve to a current finding.
 - Non-goals: type-parameter constraints, broader unsafe-dynamic-use detection, or claims that every finding is a bug or security issue.
 - The root comparison section is the canonical answer to "why not just use an existing ban-pattern linter?": overlap exists at the policy level, but `anyguard` is specifically about exact exceptions, stale-selector rejection, and a documented syntax-slot contract.


### PR DESCRIPTION
## Summary
- align the README high-level behavior summary with the documented AST-slot detection contract
- clarify that anyguard uses limited universe-`any` alias resolution to suppress shadowed declarations
- add concrete supported-slot examples (`any(1)`, `Single[any]{}`, `Box[int, any]{}`) to explain deliberate non-type-position cases
- mirror the same framing in the golangci-lint plugin docs

Resolves: #21 

## Testing
- go test ./...
- golangci-lint run
- go test -race -v ./...
- go test -bench=. -run=^$ ./...
- bash ./scripts/ci/run-golangci-plugin-smoke.sh
