### PR TITLE
refactor(validation): centralize predeclared any resolution

### DIFF
--- a/internal/validation/any_usage.go
+++ b/internal/validation/any_usage.go
@@ -36,6 +36,13 @@ var nolintDirectiveRE = regexp.MustCompile(`(?i)\bnolint(?::([a-z0-9_,-]+))?`)
 
 var universeAnyAlias = types.Universe.Lookup(anyName)
 
+func resolvesToPredeclaredAny(ident *ast.Ident, info *types.Info) bool {
+	if ident == nil || info == nil {
+		return false
+	}
+	return info.ObjectOf(ident) == universeAnyAlias
+}
+
 // Error represents a single disallowed `any` usage.
 type Error struct {
 	File     string // File mirrors Identity.File for existing callers.
@@ -850,21 +857,13 @@ func (collector *anyUsageCollector) visitSupportedSlot(category anyUsageCategory
 		return
 	}
 	ident, ok := expr.(*ast.Ident)
-	if ok && collector.isUniverseAnyAlias(ident) {
+	if ok && resolvesToPredeclaredAny(ident, collector.info) {
 		collector.usages = append(collector.usages, anyUsage{
 			identity: newFindingIdentity(collector.file, owner, category),
 			pos:      ident.Pos(),
 		})
 	}
 	collector.inspectNode(expr, owner)
-}
-
-func (collector *anyUsageCollector) isUniverseAnyAlias(ident *ast.Ident) bool {
-	if ident == nil || ident.Name != anyName || collector.info == nil {
-		return false
-	}
-	obj, ok := collector.info.Uses[ident]
-	return ok && obj == universeAnyAlias
 }
 
 func newFindingIdentity(relPath, owner string, category anyUsageCategory) FindingIdentity {

--- a/internal/validation/any_usage_test.go
+++ b/internal/validation/any_usage_test.go
@@ -471,6 +471,97 @@ func Use(value any) {
 	}
 }
 
+func TestResolvesToPredeclaredAny(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		line int
+		want bool
+	}{
+		{
+			name: "universe alias in field type",
+			src: `package p
+
+func Use(value any) {}
+`,
+			line: 3,
+			want: true,
+		},
+		{
+			name: "universe alias in conversion callee",
+			src: `package p
+
+func Use(value any) {
+	_ = any(value)
+}
+`,
+			line: 4,
+			want: true,
+		},
+		{
+			name: "user defined any declaration",
+			src: `package p
+
+type any interface{}
+`,
+			line: 3,
+			want: false,
+		},
+		{
+			name: "user defined any use",
+			src: `package p
+
+type any interface{}
+type Payload map[string]any
+`,
+			line: 4,
+			want: false,
+		},
+		{
+			name: "shadowed function any call",
+			src: `package p
+
+func any(v int) int { return v }
+
+func Use() {
+	_ = any(1)
+}
+`,
+			line: 6,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, testSamplePath, tt.src, parser.ParseComments)
+			if err != nil {
+				t.Fatalf(testParseFileErrFmt, err)
+			}
+
+			info := typeCheckTestFile(fset, file)
+			ident := findAnyIdentOnLine(t, fset, file, tt.line)
+			if got := resolvesToPredeclaredAny(ident, info); got != tt.want {
+				t.Fatalf("resolvesToPredeclaredAny(line %d) = %t, want %t", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolvesToPredeclaredAnyWithoutTypeInfo(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, testSamplePath, "package p\n\nfunc Use(value any) {}\n", parser.ParseComments)
+	if err != nil {
+		t.Fatalf(testParseFileErrFmt, err)
+	}
+
+	ident := findAnyIdentOnLine(t, fset, file, 3)
+	if resolvesToPredeclaredAny(ident, nil) {
+		t.Fatal("expected nil type info to stay quiet")
+	}
+}
+
 func TestCollectAnyUsagesIgnoresShadowedAnyAcrossSupportedSlots(t *testing.T) {
 	src := `package p
 
@@ -1182,6 +1273,30 @@ func summarizeUsages(fset *token.FileSet, usages []anyUsage) []usageSummary {
 		})
 	}
 	return summaries
+}
+
+func findAnyIdentOnLine(t *testing.T, fset *token.FileSet, file *ast.File, line int) *ast.Ident {
+	t.Helper()
+
+	var ident *ast.Ident
+	ast.Inspect(file, func(node ast.Node) bool {
+		candidate, ok := node.(*ast.Ident)
+		if !ok || candidate.Name != anyName {
+			return true
+		}
+		if fset.Position(candidate.Pos()).Line != line {
+			return true
+		}
+		if ident != nil {
+			t.Fatalf("expected one any identifier on line %d", line)
+		}
+		ident = candidate
+		return true
+	})
+	if ident == nil {
+		t.Fatalf("expected any identifier on line %d", line)
+	}
+	return ident
 }
 
 func dirEntryFromPath(t *testing.T, path string) fs.DirEntry {


### PR DESCRIPTION
## Summary
- add a shared `resolvesToPredeclaredAny` helper backed by `types.Info.ObjectOf`
- use that helper for supported-slot leaf matching without changing the explicit slot traversal matrix
- add focused tests covering universe `any`, shadowed `type any`, shadowed `func any`, and nil type info

Resolves: #22 

## Testing
- go test ./...
- golangci-lint run
- ./scripts/ci/run-golangci-plugin-smoke.sh

## Coverage
- overall coverage is unchanged at 86.2% versus `HEAD`
