### PR TITLE
feat(analyzer): use pass types info for anyguard matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ golangci-lint run
 - Stable plugin import path: `github.com/tobythehutt/anyguard/plugin`
 - Plugin name in `.golangci.yml`: `anyguard`
 - Plugin diagnostics follow the same deterministic ordering contract as the CLI and public analyzer.
+- The module plugin requests golangci-lint `typesinfo` load mode so supported-slot matching can use `analysis.Pass.TypesInfo`.
 - Integration docs and examples: `docs/golangci-lint/README.md`
 - Upstream readiness notes: `docs/golangci-lint/README.md#upstream-readiness`
 
@@ -175,6 +176,7 @@ For direct integration into `golangci-lint`, import the public analyzer entrypoi
 
 - Module path: `github.com/tobythehutt/anyguard`
 - Analyzer constructor: `anyguard.NewAnalyzer()`
+- The analyzer uses `analysis.Pass.TypesInfo` and runs despite errors so partial type info is still available on ill-typed packages.
 - Analyzer diagnostics follow the same deterministic ordering contract as the CLI and module plugin.
 
 ### License

--- a/anyguard_test.go
+++ b/anyguard_test.go
@@ -11,4 +11,7 @@ func TestNewAnalyzer(t *testing.T) {
 	if got, want := analyzer.Name, AnalyzerName; got != want {
 		t.Fatalf("analyzer name = %q, want %q", got, want)
 	}
+	if !analyzer.RunDespiteErrors {
+		t.Fatal("expected analyzer to run despite errors")
+	}
 }

--- a/docs/golangci-lint/README.md
+++ b/docs/golangci-lint/README.md
@@ -7,7 +7,8 @@
 - Linter name in `.golangci.yml`: `anyguard`
 - Module-plugin diagnostics follow the same deterministic ordering compatibility guarantee as the CLI and public analyzer.
 - The plugin uses the same AST-slot-driven contract as the CLI and public analyzer.
-- It reports `any` only in explicitly supported AST child slots and resolves the universe `any` alias to suppress shadowed declarations.
+- It requires golangci-lint `typesinfo` load mode so supported-slot matching can use `analysis.Pass.TypesInfo`.
+- It reports `any` only in explicitly supported AST child slots and resolves the universe `any` alias via `types.Info` to suppress shadowed declarations.
 - It is not a full type-position semantic classifier, so supported-slot cases such as `any(1)`, `Single[any]{}`, and `Box[int, any]{}` remain reportable by contract.
 
 ## Build a custom golangci-lint
@@ -49,6 +50,17 @@ linters:
 - `allowlist` (string): path to the YAML allowlist file. Default is `internal/ci/any_allowlist.yaml`.
 - `roots` (string or list): roots to analyze. Default is `./...`.
 - `repo-root` (string): optional repository root override for path resolution.
+
+## Load mode and performance
+
+- The module plugin requires `typesinfo` load mode.
+- This increases golangci-lint package loading cost compared with a syntax-only plugin because packages are type checked before `anyguard` runs.
+- Finding identity, allowlist matching, and diagnostic ordering do not change.
+- Measure the repository smoke path with:
+
+```bash
+/usr/bin/time -f 'elapsed=%E maxrss=%MKB' bash scripts/ci/run-golangci-plugin-smoke.sh
+```
 
 ## Upstream readiness
 

--- a/internal/validation/analyzer.go
+++ b/internal/validation/analyzer.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"errors"
 	"fmt"
+	"go/ast"
 	"go/token"
 	"os"
 	"path/filepath"
@@ -24,7 +25,10 @@ const (
 	flagRoots     = "roots"
 	flagRepoRoot  = "repo-root"
 
-	errNoRootsProvided = "no roots provided for any usage validation"
+	goModFilename = "go.mod"
+
+	errNoRootsProvided  = "no roots provided for any usage validation"
+	errMissingTypesInfo = "analysis pass missing types info"
 )
 
 // NewAnalyzer constructs a go/analysis analyzer for any-usage validation.
@@ -34,10 +38,11 @@ func NewAnalyzer() *analysis.Analyzer {
 		roots:         DefaultRoots,
 	}
 	analyzer := &analysis.Analyzer{
-		Name:       AnalyzerName,
-		Doc:        "reports disallowed usage of the Go any type",
-		Run:        cfg.run,
-		ResultType: reflect.TypeOf(analysisResult{}),
+		Name:             AnalyzerName,
+		Doc:              "reports disallowed usage of the Go any type",
+		Run:              cfg.run,
+		RunDespiteErrors: true,
+		ResultType:       reflect.TypeOf(analysisResult{}),
 	}
 	analyzer.Flags.StringVar(&cfg.allowlistPath, flagAllowlist, DefaultAllowlistPath, "path to any usage allowlist YAML")
 	analyzer.Flags.StringVar(&cfg.roots, flagRoots, DefaultRoots, "comma-separated roots to scan")
@@ -52,7 +57,9 @@ type analyzerConfig struct {
 }
 
 type analyzerFile struct {
+	content   []byte
 	relPath   string
+	syntax    *ast.File
 	tokenFile *token.File
 }
 
@@ -82,6 +89,19 @@ func (cfg *analyzerConfig) run(pass *analysis.Pass) (any, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	files, err := collectAnalyzerFiles(pass, repoRoot, roots)
+	if err != nil {
+		return nil, err
+	}
+	packageFindings, err := collectAnalyzerFindings(pass, files)
+	if err != nil {
+		return nil, err
+	}
+
+	// collectAnalyzerFindings builds packageFindings for current-package diagnostics,
+	// then collectFindings scans the full repo so resolveAllowlistIndex can validate
+	// stale selectors against findings before collectAnalyzerViolations reports them.
 	findings, err := collectFindings(repoRoot, roots, allowlist.ExcludeGlobs)
 	if err != nil {
 		return nil, err
@@ -91,11 +111,7 @@ func (cfg *analyzerConfig) run(pass *analysis.Pass) (any, error) {
 		return nil, err
 	}
 
-	files, err := collectAnalyzerFiles(pass, repoRoot, roots)
-	if err != nil {
-		return nil, err
-	}
-	reportViolations(pass, collectAnalyzerViolations(files, findings, index))
+	reportViolations(pass, collectAnalyzerViolations(files, packageFindings, index))
 	return analysisResult{}, nil
 }
 
@@ -135,7 +151,7 @@ func firstPassFilename(pass *analysis.Pass) string {
 func findGoModRoot(start string) (string, bool) {
 	dir := filepath.Clean(start)
 	for {
-		if fileExists(filepath.Join(dir, "go.mod")) {
+		if fileExists(filepath.Join(dir, goModFilename)) {
 			return dir, true
 		}
 		parent := filepath.Dir(dir)
@@ -188,12 +204,47 @@ func collectAnalyzerFiles(pass *analysis.Pass, repoRoot string, roots []string) 
 		if tokenFile == nil {
 			continue
 		}
+
+		content, err := readAnalyzerFile(pass, pos.Filename)
+		if err != nil {
+			return nil, fmt.Errorf("read analyzer file %s: %w", pos.Filename, err)
+		}
 		files = append(files, analyzerFile{
+			content:   content,
 			relPath:   relPath,
+			syntax:    file,
 			tokenFile: tokenFile,
 		})
 	}
 	return files, nil
+}
+
+func readAnalyzerFile(pass *analysis.Pass, filename string) ([]byte, error) {
+	if pass.ReadFile != nil {
+		return pass.ReadFile(filename)
+	}
+	// #nosec G304 -- filename comes from analysis pass file metadata.
+	return os.ReadFile(filename)
+}
+
+func collectAnalyzerFindings(pass *analysis.Pass, files []analyzerFile) ([]collectedFinding, error) {
+	if len(files) == 0 {
+		return nil, nil
+	}
+	if pass.TypesInfo == nil {
+		return nil, errors.New(errMissingTypesInfo)
+	}
+
+	findings := make([]collectedFinding, 0)
+	for _, file := range files {
+		findings = append(findings, collectParsedFileFindings(pass.Fset, pass.TypesInfo, parsedGoFile{
+			relPath: file.relPath,
+			content: file.content,
+			syntax:  file.syntax,
+		})...)
+	}
+	sortCollectedFindings(findings)
+	return findings, nil
 }
 
 func relativePath(repoRoot, absPath string) (string, error) {

--- a/internal/validation/analyzer_test.go
+++ b/internal/validation/analyzer_test.go
@@ -23,11 +23,15 @@ const (
 	testPkgFiltered    = "filtered"
 	testPkgDir         = "pkg"
 	testNilPkgPath     = "pkg/nilpkg.go"
+	testShadowedPath   = "pkg/shadowed.go"
 	testAnalyzerSrc    = "package pkg\ntype T map[string]any\n"
 	testCreateSource   = "create source dir: %v"
 	testWriteSource    = "write source file: %v"
 	testParseSource    = "parse source: %v"
 	testUnexpectedErr  = "unexpected error: %v"
+	testCollectFiles   = "collect files: %v"
+	testExpectedOne    = "expected one file, got %d"
+	testShadowedQuiet  = "expected shadowed any to stay quiet, got %#v"
 )
 
 func TestAnalyzer(t *testing.T) {
@@ -54,6 +58,13 @@ func TestAnalyzerRespectsRoots(t *testing.T) {
 	analysistest.Run(t, testdata, analyzer, testPkgFiltered)
 }
 
+func TestNewAnalyzerRunsDespiteErrors(t *testing.T) {
+	analyzer := NewAnalyzer()
+	if !analyzer.RunDespiteErrors {
+		t.Fatalf("expected analyzer to run despite type errors")
+	}
+}
+
 func TestCollectAnalyzerFilesWithNilPackage(t *testing.T) {
 	base := t.TempDir()
 	sourcePath := filepath.Join(base, testNilPkgPath)
@@ -77,13 +88,199 @@ func TestCollectAnalyzerFilesWithNilPackage(t *testing.T) {
 
 	files, err := collectAnalyzerFiles(pass, base, []string{DefaultRoots})
 	if err != nil {
-		t.Fatalf("collect files: %v", err)
+		t.Fatalf(testCollectFiles, err)
 	}
 	if len(files) != 1 {
-		t.Fatalf("expected one file, got %d", len(files))
+		t.Fatalf(testExpectedOne, len(files))
 	}
 	if got, want := files[0].relPath, testNilPkgPath; got != want {
 		t.Fatalf("unexpected relative path: got %q want %q", got, want)
+	}
+}
+
+func TestCollectAnalyzerFilesUsesPassReadFile(t *testing.T) {
+	base := t.TempDir()
+	sourcePath := filepath.Join(base, testNilPkgPath)
+
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, sourcePath, testAnalyzerSrc, parser.ParseComments)
+	if err != nil {
+		t.Fatalf(testParseSource, err)
+	}
+
+	pass := &analysis.Pass{
+		Fset:  fset,
+		Files: []*ast.File{parsed},
+		ReadFile: func(filename string) ([]byte, error) {
+			if filename != sourcePath {
+				t.Fatalf("unexpected read path: %q", filename)
+			}
+			return []byte(testAnalyzerSrc), nil
+		},
+	}
+
+	files, err := collectAnalyzerFiles(pass, base, []string{DefaultRoots})
+	if err != nil {
+		t.Fatalf(testCollectFiles, err)
+	}
+	if len(files) != 1 {
+		t.Fatalf(testExpectedOne, len(files))
+	}
+	if got := string(files[0].content); got != testAnalyzerSrc {
+		t.Fatalf("unexpected file content: %q", got)
+	}
+	if files[0].syntax != parsed {
+		t.Fatalf("expected parsed syntax to be reused")
+	}
+}
+
+func TestCollectAnalyzerFindingsUsesPassTypesInfo(t *testing.T) {
+	base := t.TempDir()
+	sourcePath := filepath.Join(base, testShadowedPath)
+	source := "package pkg\ntype any interface{}\ntype Payload map[string]any\nfunc Use() { _ = any(1) }\n"
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o750); err != nil {
+		t.Fatalf(testCreateSource, err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(source), 0o600); err != nil {
+		t.Fatalf(testWriteSource, err)
+	}
+
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, sourcePath, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf(testParseSource, err)
+	}
+
+	pass := &analysis.Pass{
+		Fset:      fset,
+		Files:     []*ast.File{parsed},
+		TypesInfo: typeCheckTestFile(fset, parsed),
+	}
+
+	files, err := collectAnalyzerFiles(pass, base, []string{DefaultRoots})
+	if err != nil {
+		t.Fatalf(testCollectFiles, err)
+	}
+
+	findings, err := collectAnalyzerFindings(pass, files)
+	if err != nil {
+		t.Fatalf("collect findings: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf(testShadowedQuiet, collectFindingSummaries(findings))
+	}
+}
+
+func TestCollectAnalyzerFindingsRequiresTypesInfo(t *testing.T) {
+	base := t.TempDir()
+	sourcePath := filepath.Join(base, testNilPkgPath)
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o750); err != nil {
+		t.Fatalf(testCreateSource, err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(testAnalyzerSrc), 0o600); err != nil {
+		t.Fatalf(testWriteSource, err)
+	}
+
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, sourcePath, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf(testParseSource, err)
+	}
+
+	pass := &analysis.Pass{
+		Fset:  fset,
+		Files: []*ast.File{parsed},
+	}
+
+	files, err := collectAnalyzerFiles(pass, base, []string{DefaultRoots})
+	if err != nil {
+		t.Fatalf(testCollectFiles, err)
+	}
+
+	_, err = collectAnalyzerFindings(pass, files)
+	if err == nil {
+		t.Fatalf("expected types info error")
+	}
+	if !strings.Contains(err.Error(), errMissingTypesInfo) {
+		t.Fatalf(testUnexpectedErr, err)
+	}
+}
+
+func TestCollectAnalyzerFindingsWithNoFiles(t *testing.T) {
+	findings, err := collectAnalyzerFindings(&analysis.Pass{}, nil)
+	if err != nil {
+		t.Fatalf("collect findings without files: %v", err)
+	}
+	if findings != nil {
+		t.Fatalf("expected nil findings, got %#v", findings)
+	}
+}
+
+func TestResolveAllowlistPath(t *testing.T) {
+	base := t.TempDir()
+	relative, err := resolveAllowlistPath(base, DefaultAllowlistPath)
+	if err != nil {
+		t.Fatalf("resolve relative allowlist path: %v", err)
+	}
+	if got, want := relative, filepath.Join(base, filepath.FromSlash(DefaultAllowlistPath)); got != want {
+		t.Fatalf("unexpected relative allowlist path: got %q want %q", got, want)
+	}
+
+	absolute := filepath.Join(base, "absolute.yaml")
+	resolved, err := resolveAllowlistPath(base, absolute)
+	if err != nil {
+		t.Fatalf("resolve absolute allowlist path: %v", err)
+	}
+	if resolved != absolute {
+		t.Fatalf("unexpected absolute allowlist path: %q", resolved)
+	}
+}
+
+func TestFindGoModRootAndFileExists(t *testing.T) {
+	base := t.TempDir()
+	moduleRoot := filepath.Join(base, "repo")
+	nested := filepath.Join(moduleRoot, testPkgDir, testDirAPI)
+	if err := os.MkdirAll(nested, 0o750); err != nil {
+		t.Fatalf("create nested module path: %v", err)
+	}
+
+	goMod := filepath.Join(moduleRoot, goModFilename)
+	if err := os.WriteFile(goMod, []byte("module example.com/test\n"), 0o600); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+
+	root, ok := findGoModRoot(nested)
+	if !ok {
+		t.Fatalf("expected go.mod root")
+	}
+	if root != moduleRoot {
+		t.Fatalf("unexpected go.mod root: %q", root)
+	}
+	if !fileExists(goMod) {
+		t.Fatalf("expected go.mod to exist")
+	}
+	if fileExists(filepath.Join(moduleRoot, "missing.go")) {
+		t.Fatalf("expected missing file to stay false")
+	}
+}
+
+func TestFirstPassFilename(t *testing.T) {
+	if got := firstPassFilename(&analysis.Pass{}); got != "" {
+		t.Fatalf("expected empty filename without files, got %q", got)
+	}
+
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, testSamplePath, testPackageAPISource, parser.ParseComments)
+	if err != nil {
+		t.Fatalf(testParseSource, err)
+	}
+	pass := &analysis.Pass{
+		Fset:  fset,
+		Files: []*ast.File{parsed},
+	}
+
+	if got, want := firstPassFilename(pass), testSamplePath; got != want {
+		t.Fatalf("unexpected first filename: got %q want %q", got, want)
 	}
 }
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -94,7 +94,7 @@ func (p *ModulePlugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
 
 // GetLoadMode declares the package loading mode required by this analyzer.
 func (p *ModulePlugin) GetLoadMode() string {
-	return register.LoadModeSyntax
+	return register.LoadModeTypesInfo
 }
 
 func normalizeRoots(roots []string) []string {

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -79,7 +79,7 @@ func TestModulePluginGetLoadMode(t *testing.T) {
 		t.Fatalf(errNewPlugin, err)
 	}
 
-	if got, want := pluginInstance.GetLoadMode(), register.LoadModeSyntax; got != want {
+	if got, want := pluginInstance.GetLoadMode(), register.LoadModeTypesInfo; got != want {
 		t.Fatalf("unexpected load mode: got %q want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

- use `analysis.Pass.TypesInfo` for current-package `any` matching in the analyzer
- switch the golangci module plugin load mode to `typesinfo`
- keep finding identity and diagnostic ordering unchanged
- add analyzer-path tests and document the load-mode cost

Resolves: #23 

## Testing

- `go test ./...`
- `golangci-lint run`
- `bash scripts/ci/run-golangci-plugin-smoke.sh`

## Performance

- measured on March 21, 2026 with `/usr/bin/time -f 'elapsed=%E maxrss=%MKB' bash scripts/ci/run-golangci-plugin-smoke.sh`
- prior syntax-mode smoke run was about `2.81s` and `77MB`
- typesinfo smoke run was about `18.92s` and `710MB`

## Notes

- finding identity and canonical fixture output stay unchanged
- the analyzer still does a repo-wide scan for allowlist index validation so stale selectors continue to fail closed
