### PR TITLE
fix(validation): resolve declaration slots against predeclared any

### DIFF
--- a/internal/validation/any_usage.go
+++ b/internal/validation/any_usage.go
@@ -43,6 +43,14 @@ func resolvesToPredeclaredAny(ident *ast.Ident, info *types.Info) bool {
 	return info.ObjectOf(ident) == universeAnyAlias
 }
 
+func predeclaredAnyIdent(expr ast.Expr, info *types.Info) (*ast.Ident, bool) {
+	ident, ok := expr.(*ast.Ident)
+	if !ok || !resolvesToPredeclaredAny(ident, info) {
+		return nil, false
+	}
+	return ident, true
+}
+
 // Error represents a single disallowed `any` usage.
 type Error struct {
 	File     string // File mirrors Identity.File for existing callers.
@@ -790,10 +798,10 @@ func (collector *anyUsageCollector) inspectLocalDecl(decl ast.Decl, owner string
 func (collector *anyUsageCollector) inspectTopLevelSpec(spec ast.Spec) {
 	switch node := spec.(type) {
 	case *ast.TypeSpec:
-		collector.visitSupportedSlot(anyCategoryTypeSpecType, node.Name.Name, node.Type)
+		collector.visitPredeclaredAnySlot(anyCategoryTypeSpecType, node.Name.Name, node.Type)
 	case *ast.ValueSpec:
 		owner := valueSpecOwner(node)
-		collector.visitSupportedSlot(anyCategoryValueSpecType, owner, node.Type)
+		collector.visitPredeclaredAnySlot(anyCategoryValueSpecType, owner, node.Type)
 		collector.inspectExprs(node.Values, owner)
 	}
 }
@@ -801,9 +809,9 @@ func (collector *anyUsageCollector) inspectTopLevelSpec(spec ast.Spec) {
 func (collector *anyUsageCollector) inspectLocalSpec(spec ast.Spec, owner string) {
 	switch node := spec.(type) {
 	case *ast.TypeSpec:
-		collector.visitSupportedSlot(anyCategoryTypeSpecType, owner, node.Type)
+		collector.visitPredeclaredAnySlot(anyCategoryTypeSpecType, owner, node.Type)
 	case *ast.ValueSpec:
-		collector.visitSupportedSlot(anyCategoryValueSpecType, owner, node.Type)
+		collector.visitPredeclaredAnySlot(anyCategoryValueSpecType, owner, node.Type)
 		collector.inspectExprs(node.Values, owner)
 	}
 }
@@ -836,7 +844,7 @@ func (collector *anyUsageCollector) inspectFieldList(fields *ast.FieldList, owne
 		if field == nil {
 			continue
 		}
-		collector.visitSupportedSlot(anyCategoryFieldType, owner, field.Type)
+		collector.visitPredeclaredAnySlot(anyCategoryFieldType, owner, field.Type)
 	}
 }
 
@@ -852,12 +860,11 @@ func (collector *anyUsageCollector) inspectStmts(stmts []ast.Stmt, owner string)
 	}
 }
 
-func (collector *anyUsageCollector) visitSupportedSlot(category anyUsageCategory, owner string, expr ast.Expr) {
+func (collector *anyUsageCollector) visitPredeclaredAnySlot(category anyUsageCategory, owner string, expr ast.Expr) {
 	if expr == nil {
 		return
 	}
-	ident, ok := expr.(*ast.Ident)
-	if ok && resolvesToPredeclaredAny(ident, collector.info) {
+	if ident, ok := predeclaredAnyIdent(expr, collector.info); ok {
 		collector.usages = append(collector.usages, anyUsage{
 			identity: newFindingIdentity(collector.file, owner, category),
 			pos:      ident.Pos(),
@@ -939,16 +946,16 @@ func (collector *anyUsageCollector) inspectTypeNode(node ast.Node, owner string)
 		collector.inspectFieldList(typed.Methods, owner)
 	case *ast.ArrayType:
 		collector.inspectNode(typed.Len, owner)
-		collector.visitSupportedSlot(anyCategoryArrayTypeElt, owner, typed.Elt)
+		collector.visitPredeclaredAnySlot(anyCategoryArrayTypeElt, owner, typed.Elt)
 	case *ast.MapType:
-		collector.visitSupportedSlot(anyCategoryMapTypeKey, owner, typed.Key)
-		collector.visitSupportedSlot(anyCategoryMapTypeValue, owner, typed.Value)
+		collector.visitPredeclaredAnySlot(anyCategoryMapTypeKey, owner, typed.Key)
+		collector.visitPredeclaredAnySlot(anyCategoryMapTypeValue, owner, typed.Value)
 	case *ast.ChanType:
-		collector.visitSupportedSlot(anyCategoryChanTypeValue, owner, typed.Value)
+		collector.visitPredeclaredAnySlot(anyCategoryChanTypeValue, owner, typed.Value)
 	case *ast.StarExpr:
-		collector.visitSupportedSlot(anyCategoryStarExprX, owner, typed.X)
+		collector.visitPredeclaredAnySlot(anyCategoryStarExprX, owner, typed.X)
 	case *ast.Ellipsis:
-		collector.visitSupportedSlot(anyCategoryEllipsisElt, owner, typed.Elt)
+		collector.visitPredeclaredAnySlot(anyCategoryEllipsisElt, owner, typed.Elt)
 	default:
 		return false
 	}
@@ -958,18 +965,18 @@ func (collector *anyUsageCollector) inspectTypeNode(node ast.Node, owner string)
 func (collector *anyUsageCollector) inspectExprNode(node ast.Node, owner string) bool {
 	switch typed := node.(type) {
 	case *ast.CallExpr:
-		collector.visitSupportedSlot(anyCategoryCallExprFun, owner, typed.Fun)
+		collector.visitPredeclaredAnySlot(anyCategoryCallExprFun, owner, typed.Fun)
 		collector.inspectExprs(typed.Args, owner)
 	case *ast.TypeAssertExpr:
 		collector.inspectNode(typed.X, owner)
-		collector.visitSupportedSlot(anyCategoryTypeAssertType, owner, typed.Type)
+		collector.visitPredeclaredAnySlot(anyCategoryTypeAssertType, owner, typed.Type)
 	case *ast.IndexExpr:
 		collector.inspectNode(typed.X, owner)
-		collector.visitSupportedSlot(anyCategoryIndexExprIndex, owner, typed.Index)
+		collector.visitPredeclaredAnySlot(anyCategoryIndexExprIndex, owner, typed.Index)
 	case *ast.IndexListExpr:
 		collector.inspectNode(typed.X, owner)
 		for _, index := range typed.Indices {
-			collector.visitSupportedSlot(anyCategoryIndexListIndex, owner, index)
+			collector.visitPredeclaredAnySlot(anyCategoryIndexListIndex, owner, index)
 		}
 	case *ast.CompositeLit:
 		collector.inspectNode(typed.Type, owner)

--- a/internal/validation/any_usage_test.go
+++ b/internal/validation/any_usage_test.go
@@ -214,7 +214,24 @@ func TestValidateAnyUsageAllowsTypeParamConstraint(t *testing.T) {
 func TestValidateAnyUsageIgnoresPackageShadowedAnyAcrossFiles(t *testing.T) {
 	base := t.TempDir()
 	writeFile(t, apiPath(base, "defs.go"), "package api\ntype any interface{}\ntype Single[T any] struct{}\ntype Box[T, U any] struct{}\n")
-	writeFile(t, apiPath(base, "uses.go"), "package api\ntype Payload map[string]any\nfunc Use() {\n\t_ = any(1)\n\t_ = Single[any]{}\n\t_ = Box[int, any]{}\n}\n")
+	writeFile(
+		t,
+		apiPath(base, "uses.go"),
+		"package api\n"+
+			"func FieldType(value any) {}\n"+
+			"var ValueSpec any\n"+
+			"type TypeSpec = any\n"+
+			"type Payload map[string]any\n"+
+			"func Use(value interface{}) {\n"+
+			"\tvar local any\n"+
+			"\ttype Hidden = any\n"+
+			"\t_ = value.(any)\n"+
+			"\t_ = any(1)\n"+
+			"\t_ = Single[any]{}\n"+
+			"\t_ = Box[int, any]{}\n"+
+			"\t_ = local\n"+
+			"}\n",
+	)
 
 	violations, err := ValidateAnyUsage(AnyAllowlist{Version: anyAllowlistVersion}, base, []string{testRootAPI})
 	if err != nil {
@@ -222,6 +239,62 @@ func TestValidateAnyUsageIgnoresPackageShadowedAnyAcrossFiles(t *testing.T) {
 	}
 	if len(violations) != 0 {
 		t.Fatalf(testNoViolationsErrFmt, violations)
+	}
+}
+
+func TestCollectAnyUsagesReportsDeclarationSlotsOnlyForPredeclaredAny(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []usageSummary
+	}{
+		{
+			name: "predeclared any",
+			src: `package p
+
+func FieldType(value any) {}
+
+var ValueSpec any
+
+type TypeSpec = any
+
+func TypeAssert(value interface{}) {
+	_ = value.(any)
+}
+`,
+			want: []usageSummary{
+				{category: anyCategoryFieldType, owner: "FieldType", line: 3},
+				{category: anyCategoryValueSpecType, owner: "ValueSpec", line: 5},
+				{category: anyCategoryTypeSpecType, owner: "TypeSpec", line: 7},
+				{category: anyCategoryTypeAssertType, owner: "TypeAssert", line: 10},
+			},
+		},
+		{
+			name: "shadowed any",
+			src: `package p
+
+type any interface{}
+
+func FieldType(value any) {}
+
+var ValueSpec any
+
+type TypeSpec = any
+
+func TypeAssert(value interface{}) {
+	_ = value.(any)
+}
+`,
+			want: []usageSummary{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := collectUsageSummaries(t, tt.src); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("unexpected declaration-slot usages:\ngot: %#v\nwant: %#v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/validation/corpus_test.go
+++ b/internal/validation/corpus_test.go
@@ -11,6 +11,7 @@ import (
 const (
 	corpusFixtureSupported          = "supported"
 	corpusFixtureBoundary           = "boundary"
+	corpusFixtureDeclarationSlots   = "declaration-slots"
 	corpusFixtureUnsupported        = "unsupported"
 	corpusFixtureAllowlistHygiene   = "allowlist-hygiene"
 	corpusFixtureStabilityBase      = "stability/base"
@@ -67,6 +68,43 @@ func TestValidateAnyUsageCorpusUnsupportedContexts(t *testing.T) {
 	got := collectViolationSummaries(mustValidateCorpus(t, corpusFixtureUnsupported, testAllowlistEmpty, []string{DefaultRoots}))
 	if len(got) != 0 {
 		t.Fatalf("expected unsupported corpus to remain unreported, got %#v", got)
+	}
+}
+
+func TestValidateAnyUsageCorpusDeclarationSlots(t *testing.T) {
+	got := collectViolationSummaries(mustValidateCorpus(t, corpusFixtureDeclarationSlots, testAllowlistEmpty, []string{DefaultRoots}))
+	want := []violationSummary{
+		{
+			file:     "pkg/predeclared/declarations.go",
+			owner:    "FieldTypePredeclared",
+			category: string(anyCategoryFieldType),
+			line:     3,
+			column:   33,
+		},
+		{
+			file:     "pkg/predeclared/declarations.go",
+			owner:    "ValueSpecPredeclared",
+			category: string(anyCategoryValueSpecType),
+			line:     5,
+			column:   26,
+		},
+		{
+			file:     "pkg/predeclared/declarations.go",
+			owner:    "TypeSpecPredeclared",
+			category: string(anyCategoryTypeSpecType),
+			line:     7,
+			column:   28,
+		},
+		{
+			file:     "pkg/predeclared/declarations.go",
+			owner:    "TypeAssertPredeclared",
+			category: string(anyCategoryTypeAssertType),
+			line:     10,
+			column:   13,
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected declaration-slot corpus violations:\ngot: %#v\nwant: %#v", got, want)
 	}
 }
 

--- a/internal/validation/testdata/corpus/declaration-slots/allowlist-empty.yaml
+++ b/internal/validation/testdata/corpus/declaration-slots/allowlist-empty.yaml
@@ -1,0 +1,2 @@
+version: 2
+entries: []

--- a/internal/validation/testdata/corpus/declaration-slots/pkg/predeclared/declarations.go
+++ b/internal/validation/testdata/corpus/declaration-slots/pkg/predeclared/declarations.go
@@ -1,0 +1,11 @@
+package predeclared
+
+func FieldTypePredeclared(value any) {}
+
+var ValueSpecPredeclared any
+
+type TypeSpecPredeclared = any
+
+func TypeAssertPredeclared(value interface{}) {
+	_ = value.(any)
+}

--- a/internal/validation/testdata/corpus/declaration-slots/pkg/shadowed/declarations.go
+++ b/internal/validation/testdata/corpus/declaration-slots/pkg/shadowed/declarations.go
@@ -1,0 +1,13 @@
+package shadowed
+
+type any interface{}
+
+func FieldTypeShadowed(value any) {}
+
+var ValueSpecShadowed any
+
+type TypeSpecShadowed = any
+
+func TypeAssertShadowed(value interface{}) {
+	_ = value.(any)
+}


### PR DESCRIPTION
## Summary

- route declaration-level any slots through the shared predeclared-any resolver
- suppress reports for user-defined `type any ...` in field, value spec, type spec, and type assertion slots
- add unit and corpus coverage for predeclared vs shadowed declaration-slot cases

Resolves: #24 

## Testing

- go build ./...
- go test ./...
- go test -race ./...
- go test -bench=. -run=^$ ./...
- go test -coverprofile=/tmp/anyguard-cover-after.out ./...
- golangci-lint run
- bash ./scripts/ci/run-golangci-plugin-smoke.sh