### PR TITLE
fix(validation): require semantic any for composite slots

### DIFF
--- a/internal/validation/any_usage.go
+++ b/internal/validation/any_usage.go
@@ -864,13 +864,25 @@ func (collector *anyUsageCollector) visitPredeclaredAnySlot(category anyUsageCat
 	if expr == nil {
 		return
 	}
+	collector.recordPredeclaredAnyUsage(category, owner, expr)
+	collector.inspectNode(expr, owner)
+}
+
+func (collector *anyUsageCollector) visitCompositeTypeAnySlot(category anyUsageCategory, owner string, expr ast.Expr) {
+	if expr == nil {
+		return
+	}
+	collector.recordPredeclaredAnyUsage(category, owner, expr)
+	collector.inspectNode(expr, owner)
+}
+
+func (collector *anyUsageCollector) recordPredeclaredAnyUsage(category anyUsageCategory, owner string, expr ast.Expr) {
 	if ident, ok := predeclaredAnyIdent(expr, collector.info); ok {
 		collector.usages = append(collector.usages, anyUsage{
 			identity: newFindingIdentity(collector.file, owner, category),
 			pos:      ident.Pos(),
 		})
 	}
-	collector.inspectNode(expr, owner)
 }
 
 func newFindingIdentity(relPath, owner string, category anyUsageCategory) FindingIdentity {
@@ -946,16 +958,16 @@ func (collector *anyUsageCollector) inspectTypeNode(node ast.Node, owner string)
 		collector.inspectFieldList(typed.Methods, owner)
 	case *ast.ArrayType:
 		collector.inspectNode(typed.Len, owner)
-		collector.visitPredeclaredAnySlot(anyCategoryArrayTypeElt, owner, typed.Elt)
+		collector.visitCompositeTypeAnySlot(anyCategoryArrayTypeElt, owner, typed.Elt)
 	case *ast.MapType:
-		collector.visitPredeclaredAnySlot(anyCategoryMapTypeKey, owner, typed.Key)
-		collector.visitPredeclaredAnySlot(anyCategoryMapTypeValue, owner, typed.Value)
+		collector.visitCompositeTypeAnySlot(anyCategoryMapTypeKey, owner, typed.Key)
+		collector.visitCompositeTypeAnySlot(anyCategoryMapTypeValue, owner, typed.Value)
 	case *ast.ChanType:
-		collector.visitPredeclaredAnySlot(anyCategoryChanTypeValue, owner, typed.Value)
+		collector.visitCompositeTypeAnySlot(anyCategoryChanTypeValue, owner, typed.Value)
 	case *ast.StarExpr:
-		collector.visitPredeclaredAnySlot(anyCategoryStarExprX, owner, typed.X)
+		collector.visitCompositeTypeAnySlot(anyCategoryStarExprX, owner, typed.X)
 	case *ast.Ellipsis:
-		collector.visitPredeclaredAnySlot(anyCategoryEllipsisElt, owner, typed.Elt)
+		collector.visitCompositeTypeAnySlot(anyCategoryEllipsisElt, owner, typed.Elt)
 	default:
 		return false
 	}

--- a/internal/validation/any_usage_test.go
+++ b/internal/validation/any_usage_test.go
@@ -298,6 +298,82 @@ func TypeAssert(value interface{}) {
 	}
 }
 
+func TestCollectAnyUsagesReportsCompositeTypeSlotsOnlyForPredeclaredAny(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []usageSummary
+	}{
+		{
+			name: "predeclared any",
+			src: `package p
+
+type ArrayAlias = []any
+type MapKeyAlias = map[any]string
+type MapValueAlias = map[string]any
+type ChanAlias = chan any
+type StarAlias = *any
+
+type NestedArrayAlias = map[string][]any
+type NestedMapAlias = []map[string]any
+
+func EllipsisAlias(values ...any) {}
+func NestedEllipsisAlias(values ...[]any) {}
+`,
+			want: []usageSummary{
+				{category: anyCategoryArrayTypeElt, owner: "ArrayAlias", line: 3},
+				{category: anyCategoryMapTypeKey, owner: "MapKeyAlias", line: 4},
+				{category: anyCategoryMapTypeValue, owner: "MapValueAlias", line: 5},
+				{category: anyCategoryChanTypeValue, owner: "ChanAlias", line: 6},
+				{category: anyCategoryStarExprX, owner: "StarAlias", line: 7},
+				{category: anyCategoryArrayTypeElt, owner: "NestedArrayAlias", line: 9},
+				{category: anyCategoryMapTypeValue, owner: "NestedMapAlias", line: 10},
+				{category: anyCategoryEllipsisElt, owner: "EllipsisAlias", line: 12},
+				{category: anyCategoryArrayTypeElt, owner: "NestedEllipsisAlias", line: 13},
+			},
+		},
+		{
+			name: "shadowed any",
+			src: `package p
+
+type any interface{}
+
+type ArrayAlias = []any
+type MapKeyAlias = map[any]string
+type MapValueAlias = map[string]any
+type ChanAlias = chan any
+type StarAlias = *any
+
+type NestedArrayAlias = map[string][]any
+type NestedMapAlias = []map[string]any
+
+func EllipsisAlias(values ...any) {}
+func NestedEllipsisAlias(values ...[]any) {}
+`,
+			want: []usageSummary{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := collectUsageSummaries(t, tt.src); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("unexpected composite-slot usages:\ngot: %#v\nwant: %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVisitCompositeTypeAnySlotIgnoresNilExpr(t *testing.T) {
+	collector := anyUsageCollector{
+		file: testSamplePath,
+		info: &types.Info{Uses: make(map[*ast.Ident]types.Object)},
+	}
+	collector.visitCompositeTypeAnySlot(anyCategoryArrayTypeElt, "Owner", nil)
+	if len(collector.usages) != 0 {
+		t.Fatalf("expected nil composite slot to stay quiet, got %#v", collector.usages)
+	}
+}
+
 func TestValidateAnyUsageErrorCases(t *testing.T) {
 	base := t.TempDir()
 	writeFile(t, apiPath(base, "ok.go"), testPackageAPISource)

--- a/internal/validation/corpus_test.go
+++ b/internal/validation/corpus_test.go
@@ -12,6 +12,7 @@ const (
 	corpusFixtureSupported          = "supported"
 	corpusFixtureBoundary           = "boundary"
 	corpusFixtureDeclarationSlots   = "declaration-slots"
+	corpusFixtureCompositeSlots     = "composite-slots"
 	corpusFixtureUnsupported        = "unsupported"
 	corpusFixtureAllowlistHygiene   = "allowlist-hygiene"
 	corpusFixtureStabilityBase      = "stability/base"
@@ -105,6 +106,78 @@ func TestValidateAnyUsageCorpusDeclarationSlots(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected declaration-slot corpus violations:\ngot: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestValidateAnyUsageCorpusCompositeSlots(t *testing.T) {
+	got := collectViolationSummaries(mustValidateCorpus(t, corpusFixtureCompositeSlots, testAllowlistEmpty, []string{DefaultRoots}))
+	want := []violationSummary{
+		{
+			file:     "pkg/predeclared/composites.go",
+			owner:    "ArrayAlias",
+			category: string(anyCategoryArrayTypeElt),
+			line:     3,
+			column:   21,
+		},
+		{
+			file:     "pkg/predeclared/composites.go",
+			owner:    "MapKeyAlias",
+			category: string(anyCategoryMapTypeKey),
+			line:     4,
+			column:   24,
+		},
+		{
+			file:     "pkg/predeclared/composites.go",
+			owner:    "MapValueAlias",
+			category: string(anyCategoryMapTypeValue),
+			line:     5,
+			column:   33,
+		},
+		{
+			file:     "pkg/predeclared/composites.go",
+			owner:    "ChanAlias",
+			category: string(anyCategoryChanTypeValue),
+			line:     6,
+			column:   23,
+		},
+		{
+			file:     "pkg/predeclared/composites.go",
+			owner:    "StarAlias",
+			category: string(anyCategoryStarExprX),
+			line:     7,
+			column:   19,
+		},
+		{
+			file:     "pkg/predeclared/composites.go",
+			owner:    "NestedArrayAlias",
+			category: string(anyCategoryArrayTypeElt),
+			line:     9,
+			column:   38,
+		},
+		{
+			file:     "pkg/predeclared/composites.go",
+			owner:    "NestedMapAlias",
+			category: string(anyCategoryMapTypeValue),
+			line:     10,
+			column:   36,
+		},
+		{
+			file:     "pkg/predeclared/composites.go",
+			owner:    "EllipsisAlias",
+			category: string(anyCategoryEllipsisElt),
+			line:     12,
+			column:   30,
+		},
+		{
+			file:     "pkg/predeclared/composites.go",
+			owner:    "NestedEllipsisAlias",
+			category: string(anyCategoryArrayTypeElt),
+			line:     13,
+			column:   38,
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected composite-slot corpus violations:\ngot: %#v\nwant: %#v", got, want)
 	}
 }
 

--- a/internal/validation/testdata/corpus/composite-slots/allowlist-empty.yaml
+++ b/internal/validation/testdata/corpus/composite-slots/allowlist-empty.yaml
@@ -1,0 +1,2 @@
+version: 2
+entries: []

--- a/internal/validation/testdata/corpus/composite-slots/pkg/predeclared/composites.go
+++ b/internal/validation/testdata/corpus/composite-slots/pkg/predeclared/composites.go
@@ -1,0 +1,13 @@
+package predeclared
+
+type ArrayAlias = []any
+type MapKeyAlias = map[any]string
+type MapValueAlias = map[string]any
+type ChanAlias = chan any
+type StarAlias = *any
+
+type NestedArrayAlias = map[string][]any
+type NestedMapAlias = []map[string]any
+
+func EllipsisAlias(values ...any)         {}
+func NestedEllipsisAlias(values ...[]any) {}

--- a/internal/validation/testdata/corpus/composite-slots/pkg/shadowed/composites.go
+++ b/internal/validation/testdata/corpus/composite-slots/pkg/shadowed/composites.go
@@ -1,0 +1,15 @@
+package shadowed
+
+type any interface{}
+
+type ArrayAlias = []any
+type MapKeyAlias = map[any]string
+type MapValueAlias = map[string]any
+type ChanAlias = chan any
+type StarAlias = *any
+
+type NestedArrayAlias = map[string][]any
+type NestedMapAlias = []map[string]any
+
+func EllipsisAlias(values ...any)         {}
+func NestedEllipsisAlias(values ...[]any) {}


### PR DESCRIPTION
## Summary
- refactor nested composite type slots to use semantic universe-`any` resolution
- preserve nested real-`any` findings such as `map[string][]any` on the innermost supported slot
- add unit and corpus coverage for aliased, nested, and shadowed composite forms

Resolves: #25 

## Testing
- go test ./...
- golangci-lint run
