### PR TITLE
perf(validation): cache repo-wide analyzer validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require (
-	golang.org/x/mod v0.23.0 // indirect
-	golang.org/x/sync v0.11.0 // indirect
-)
+require golang.org/x/sync v0.11.0
+
+require golang.org/x/mod v0.23.0 // indirect

--- a/internal/benchtest/benchtest.go
+++ b/internal/benchtest/benchtest.go
@@ -157,7 +157,6 @@ func CopyModuleTree(tb testing.TB, srcRoot string) string {
 	return dstRoot
 }
 
-//nolint:gosec // Benchmark fixtures only copy repository-controlled files into t.TempDir.
 func copyModuleTreeEntry(srcRoot, dstRoot, path string, entry os.DirEntry, walkErr error) error {
 	if walkErr != nil {
 		return walkErr
@@ -180,10 +179,12 @@ func copyModuleTreeEntry(srcRoot, dstRoot, path string, entry os.DirEntry, walkE
 		return mkdirErr
 	}
 
+	// #nosec G304 -- path is discovered from a repository-rooted filepath.WalkDir.
 	data, readErr := os.ReadFile(path)
 	if readErr != nil {
 		return readErr
 	}
+	// #nosec G703 -- relPath comes from filepath.Rel during a walk rooted at srcRoot.
 	return os.WriteFile(dstPath, data, 0o600)
 }
 

--- a/internal/validation/analyzer.go
+++ b/internal/validation/analyzer.go
@@ -85,10 +85,11 @@ func (cfg *analyzerConfig) run(pass *analysis.Pass) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	allowlist, err := LoadAnyAllowlist(allowlistPath)
+	loadedAllowlist, err := loadAnyAllowlist(allowlistPath)
 	if err != nil {
 		return nil, err
 	}
+	allowlist := loadedAllowlist.allowlist
 
 	files, err := collectAnalyzerFiles(pass, repoRoot, roots)
 	if err != nil {
@@ -100,18 +101,13 @@ func (cfg *analyzerConfig) run(pass *analysis.Pass) (any, error) {
 	}
 
 	// collectAnalyzerFindings builds packageFindings for current-package diagnostics,
-	// then collectFindings scans the full repo so resolveAllowlistIndex can validate
-	// stale selectors against findings before collectAnalyzerViolations reports them.
-	findings, err := collectFindings(repoRoot, roots, allowlist.ExcludeGlobs)
-	if err != nil {
-		return nil, err
-	}
-	index, err := resolveAllowlistIndex(allowlist, findings)
+	// while repo-wide validation is cached across analyzer passes in the same process.
+	repoResult, err := loadRepoValidationResult(repoRoot, roots, allowlist, loadedAllowlist.fingerprint)
 	if err != nil {
 		return nil, err
 	}
 
-	reportViolations(pass, collectAnalyzerViolations(files, packageFindings, index))
+	reportViolations(pass, collectAnalyzerViolations(files, packageFindings, repoResult.index))
 	return analysisResult{}, nil
 }
 

--- a/internal/validation/any_usage.go
+++ b/internal/validation/any_usage.go
@@ -3,6 +3,7 @@ package validation
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"go/ast"
@@ -90,14 +91,39 @@ type AnyAllowlistEntry struct {
 	Refs        []string              `yaml:"refs,omitempty"`
 }
 
+type loadedAnyAllowlist struct {
+	allowlist   AnyAllowlist
+	fingerprint string
+}
+
 // LoadAnyAllowlist reads and validates a YAML any-usage allowlist file.
 func LoadAnyAllowlist(listPath string) (AnyAllowlist, error) {
+	loaded, err := loadAnyAllowlist(listPath)
+	if err != nil {
+		return AnyAllowlist{}, err
+	}
+	return loaded.allowlist, nil
+}
+
+func loadAnyAllowlist(listPath string) (loadedAnyAllowlist, error) {
 	// #nosec G304 -- repository tooling controls allowlist path.
 	data, err := os.ReadFile(listPath)
 	if err != nil {
-		return AnyAllowlist{}, fmt.Errorf("read any allowlist: %w", err)
+		return loadedAnyAllowlist{}, fmt.Errorf("read any allowlist: %w", err)
 	}
 
+	allowlist, err := decodeAnyAllowlist(data)
+	if err != nil {
+		return loadedAnyAllowlist{}, err
+	}
+
+	return loadedAnyAllowlist{
+		allowlist:   allowlist,
+		fingerprint: fingerprintAnyAllowlistData(data),
+	}, nil
+}
+
+func decodeAnyAllowlist(data []byte) (AnyAllowlist, error) {
 	var allowlist AnyAllowlist
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)
@@ -110,6 +136,11 @@ func LoadAnyAllowlist(listPath string) (AnyAllowlist, error) {
 		return AnyAllowlist{}, validateErr
 	}
 	return allowlist, nil
+}
+
+func fingerprintAnyAllowlistData(data []byte) string {
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum[:])
 }
 
 func wrapAllowlistParseError(err error) error {

--- a/internal/validation/benchmark_test.go
+++ b/internal/validation/benchmark_test.go
@@ -109,10 +109,12 @@ func BenchmarkAnalyzerRun(b *testing.B) {
 		roots:         DefaultRoots,
 	}
 
+	resetProcessRepoValidationCacheForTesting()
 	preloadedSnapshot := loadRepresentativeSnapshot(b, fixture)
 	if count := benchmarkAnalyzerDiagnostics(b, cfg, preloadedSnapshot); count == 0 {
 		b.Fatal(errExpectedAnalyzerDiagnostics)
 	}
+	resetProcessRepoValidationCacheForTesting()
 
 	b.Run(fixtureName+"/cold-pass", func(b *testing.B) {
 		benchmarkAnalyzerRunCold(b, cfg, fixture)
@@ -120,6 +122,10 @@ func BenchmarkAnalyzerRun(b *testing.B) {
 
 	b.Run(fixtureName+"/reused-pass", func(b *testing.B) {
 		benchmarkAnalyzerRunReused(b, cfg, preloadedSnapshot)
+	})
+
+	b.Run(fixtureName+"/reused-pass-reset-cache", func(b *testing.B) {
+		benchmarkAnalyzerRunReusedResetCache(b, cfg, preloadedSnapshot)
 	})
 }
 
@@ -180,6 +186,7 @@ func benchmarkAnalyzerRunCold(b *testing.B, cfg *analyzerConfig, fixture benchte
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
+		resetProcessRepoValidationCacheForTesting()
 		snapshot := loadRepresentativeSnapshot(b, fixture)
 		if count := benchmarkAnalyzerDiagnostics(b, cfg, snapshot); count == 0 {
 			b.Fatal(errExpectedAnalyzerDiagnostics)
@@ -191,10 +198,47 @@ func benchmarkAnalyzerRunReused(b *testing.B, cfg *analyzerConfig, snapshot benc
 	b.Helper()
 	b.ReportAllocs()
 
+	resetProcessRepoValidationCacheForTesting()
+
 	// Reuse the same prepared pass across iterations to isolate repeated in-process
 	// analyzer execution. pass.Report is reassigned each loop before cfg.run.
 	pass := benchtest.NewPass(snapshot, NewAnalyzer(), nil)
+	warmDiagnostics := 0
+	pass.Report = func(analysis.Diagnostic) {
+		warmDiagnostics++
+	}
+	if _, err := cfg.run(pass); err != nil {
+		b.Fatalf(errBenchmarkRunAnalyzer, err)
+	}
+	if warmDiagnostics == 0 {
+		b.Fatal(errExpectedAnalyzerDiagnostics)
+	}
+
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		diagnosticCount := 0
+		pass.Report = func(analysis.Diagnostic) {
+			diagnosticCount++
+		}
+		if _, err := cfg.run(pass); err != nil {
+			b.Fatalf(errBenchmarkRunAnalyzer, err)
+		}
+		if diagnosticCount == 0 {
+			b.Fatal(errExpectedAnalyzerDiagnostics)
+		}
+	}
+}
+
+func benchmarkAnalyzerRunReusedResetCache(b *testing.B, cfg *analyzerConfig, snapshot benchtest.PackageSnapshot) {
+	b.Helper()
+	b.ReportAllocs()
+
+	// Reset the process-wide repo cache each loop to preserve an uncached baseline
+	// alongside the warm repeated-pass measurement above.
+	pass := benchtest.NewPass(snapshot, NewAnalyzer(), nil)
+	for i := 0; i < b.N; i++ {
+		resetProcessRepoValidationCacheForTesting()
+
 		diagnosticCount := 0
 		pass.Report = func(analysis.Diagnostic) {
 			diagnosticCount++

--- a/internal/validation/repo_validation_cache.go
+++ b/internal/validation/repo_validation_cache.go
@@ -1,0 +1,137 @@
+package validation
+
+import (
+	"errors"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+)
+
+type repoValidationResult struct {
+	index anyAllowlistIndex
+}
+
+type repoValidationCacheKey struct {
+	repoRoot    string
+	roots       string
+	allowlistID string
+	exclude     string
+}
+
+type repoValidationCache struct {
+	entries sync.Map
+	group   singleflight.Group
+}
+
+// processRepoValidationCache is intentionally append-only for the lifetime of a
+// single anyguard tool process. Analyzer, CLI, and golangci-lint runs are
+// short-lived and use a small set of repo/config combinations, so adding
+// eviction would increase hot-path synchronization without a practical benefit.
+var processRepoValidationCache repoValidationCache
+
+var repoValidationResultCollector = collectRepoValidationResult
+
+func loadRepoValidationResult(
+	repoRoot string,
+	roots []string,
+	allowlist AnyAllowlist,
+	allowlistFingerprint string,
+) (repoValidationResult, error) {
+	key := newRepoValidationCacheKey(repoRoot, roots, allowlistFingerprint, allowlist.ExcludeGlobs)
+	return processRepoValidationCache.load(key, func() (repoValidationResult, error) {
+		return repoValidationResultCollector(repoRoot, roots, allowlist)
+	})
+}
+
+func collectRepoValidationResult(repoRoot string, roots []string, allowlist AnyAllowlist) (repoValidationResult, error) {
+	findings, err := collectFindings(repoRoot, roots, allowlist.ExcludeGlobs)
+	if err != nil {
+		return repoValidationResult{}, err
+	}
+
+	index, err := resolveAllowlistIndex(allowlist, findings)
+	if err != nil {
+		return repoValidationResult{}, err
+	}
+
+	return repoValidationResult{index: index}, nil
+}
+
+func newRepoValidationCacheKey(
+	repoRoot string,
+	roots []string,
+	allowlistFingerprint string,
+	excludeGlobs []string,
+) repoValidationCacheKey {
+	cleanRepoRoot := filepath.Clean(repoRoot)
+	normalizedRoots := normalizeConfiguredRoots(roots, cleanRepoRoot)
+	sort.Strings(normalizedRoots)
+
+	normalizedGlobs := normalizeRepoValidationCacheGlobs(excludeGlobs)
+	sort.Strings(normalizedGlobs)
+
+	return repoValidationCacheKey{
+		repoRoot:    filepath.ToSlash(cleanRepoRoot),
+		roots:       strings.Join(normalizedRoots, "\n"),
+		allowlistID: strings.TrimSpace(allowlistFingerprint),
+		exclude:     strings.Join(normalizedGlobs, "\n"),
+	}
+}
+
+func normalizeRepoValidationCacheGlobs(globs []string) []string {
+	normalized := make([]string, 0, len(globs))
+	for _, glob := range globs {
+		glob = normalizePath(glob)
+		if glob == "" {
+			continue
+		}
+		normalized = append(normalized, glob)
+	}
+	return normalized
+}
+
+func (cache *repoValidationCache) load(
+	key repoValidationCacheKey,
+	collect func() (repoValidationResult, error),
+) (repoValidationResult, error) {
+	if cached, found := cache.entries.Load(key); found {
+		cachedResult, ok := cached.(repoValidationResult)
+		if ok {
+			return cachedResult, nil
+		}
+	}
+
+	value, err, _ := cache.group.Do(key.singleflightKey(), func() (any, error) {
+		if cached, ok := cache.entries.Load(key); ok {
+			return cached, nil
+		}
+
+		result, collectErr := collect()
+		if collectErr != nil {
+			return repoValidationResult{}, collectErr
+		}
+
+		cache.entries.Store(key, result)
+		return result, nil
+	})
+	if err != nil {
+		return repoValidationResult{}, err
+	}
+
+	result, ok := value.(repoValidationResult)
+	if ok {
+		return result, nil
+	}
+	return repoValidationResult{}, errors.New("unexpected repo validation cache value type")
+}
+
+func (key repoValidationCacheKey) singleflightKey() string {
+	return strings.Join([]string{key.repoRoot, key.roots, key.allowlistID, key.exclude}, "\x00")
+}
+
+func resetProcessRepoValidationCacheForTesting() {
+	processRepoValidationCache = repoValidationCache{}
+}

--- a/internal/validation/repo_validation_cache_test.go
+++ b/internal/validation/repo_validation_cache_test.go
@@ -1,0 +1,219 @@
+package validation
+
+import (
+	"path/filepath"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tobythehutt/anyguard/internal/benchtest"
+	"golang.org/x/tools/go/analysis"
+)
+
+const (
+	testCacheRepoName     = "repo"
+	testCacheFingerprintA = "fingerprint-a"
+	testCacheFingerprintB = "fingerprint-b"
+)
+
+func TestNewRepoValidationCacheKeyNormalizesInputs(t *testing.T) {
+	base := t.TempDir()
+	repoRoot := filepath.Join(base, testCacheRepoName, ".")
+	keyA := newRepoValidationCacheKey(
+		repoRoot,
+		[]string{"./...", filepath.Join(base, testCacheRepoName, testDirPkg, testDirAPI)},
+		testCacheFingerprintA,
+		[]string{" ./internal/** ", "**/*_test.go"},
+	)
+	keyB := newRepoValidationCacheKey(
+		filepath.Join(base, testCacheRepoName),
+		[]string{"pkg/api", "."},
+		testCacheFingerprintA,
+		[]string{"**/*_test.go", "internal/**"},
+	)
+
+	if keyA != keyB {
+		t.Fatalf("expected normalized keys to match:\nkeyA=%#v\nkeyB=%#v", keyA, keyB)
+	}
+
+	keyC := newRepoValidationCacheKey(
+		filepath.Join(base, testCacheRepoName),
+		[]string{"pkg/api", "."},
+		testCacheFingerprintB,
+		[]string{"**/*_test.go", "internal/**"},
+	)
+	if keyA == keyC {
+		t.Fatalf("expected allowlist fingerprint to affect cache key")
+	}
+}
+
+func TestRepoValidationCacheReusesNormalizedKey(t *testing.T) {
+	var cache repoValidationCache
+	base := t.TempDir()
+
+	keyA := newRepoValidationCacheKey(
+		filepath.Join(base, testCacheRepoName, "."),
+		[]string{"./...", filepath.Join(base, testCacheRepoName, testDirPkg, testDirAPI)},
+		testCacheFingerprintA,
+		[]string{" ./internal/** ", "**/*_test.go"},
+	)
+	keyB := newRepoValidationCacheKey(
+		filepath.Join(base, testCacheRepoName),
+		[]string{"pkg/api", "."},
+		testCacheFingerprintA,
+		[]string{"**/*_test.go", "internal/**"},
+	)
+
+	want := repoValidationResult{
+		index: anyAllowlistIndex{
+			allowed: map[FindingIdentity]struct{}{
+				newFindingIdentity(testPayloadPath, testOwnerPayload, anyCategoryMapTypeValue): {},
+			},
+		},
+	}
+
+	var calls atomic.Int64
+	collect := func() (repoValidationResult, error) {
+		calls.Add(1)
+		return want, nil
+	}
+
+	gotA, err := cache.load(keyA, collect)
+	if err != nil {
+		t.Fatalf("load keyA: %v", err)
+	}
+	gotB, err := cache.load(keyB, collect)
+	if err != nil {
+		t.Fatalf("load keyB: %v", err)
+	}
+
+	if calls.Load() != 1 {
+		t.Fatalf("expected one cache miss, got %d", calls.Load())
+	}
+	if !reflect.DeepEqual(gotA, want) {
+		t.Fatalf("unexpected cached result for keyA: got %#v want %#v", gotA, want)
+	}
+	if !reflect.DeepEqual(gotB, want) {
+		t.Fatalf("unexpected cached result for keyB: got %#v want %#v", gotB, want)
+	}
+}
+
+func TestRepoValidationCacheConcurrentAccessCollapsesMisses(t *testing.T) {
+	var cache repoValidationCache
+	key := newRepoValidationCacheKey(
+		filepath.Join(t.TempDir(), testCacheRepoName),
+		[]string{DefaultRoots},
+		testCacheFingerprintA,
+		[]string{"**/*_test.go"},
+	)
+
+	want := repoValidationResult{
+		index: anyAllowlistIndex{
+			allowed: map[FindingIdentity]struct{}{
+				newFindingIdentity(testPayloadPath, testOwnerPayload, anyCategoryMapTypeValue): {},
+			},
+		},
+	}
+
+	var calls atomic.Int64
+	collect := func() (repoValidationResult, error) {
+		calls.Add(1)
+		time.Sleep(25 * time.Millisecond)
+		return want, nil
+	}
+
+	const goroutineCount = 16
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make(chan repoValidationResult, goroutineCount)
+	errs := make(chan error, goroutineCount)
+
+	for i := 0; i < goroutineCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			got, err := cache.load(key, collect)
+			results <- got
+			errs <- err
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	if calls.Load() != 1 {
+		t.Fatalf("expected one concurrent cache miss, got %d", calls.Load())
+	}
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("unexpected concurrent cache error: %v", err)
+		}
+	}
+	for got := range results {
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("unexpected concurrent cached result: got %#v want %#v", got, want)
+		}
+	}
+}
+
+func TestAnalyzerRunReusesRepoValidationCacheAcrossPasses(t *testing.T) {
+	resetProcessRepoValidationCacheForTesting()
+	t.Cleanup(resetProcessRepoValidationCacheForTesting)
+
+	fixture := benchtest.CreateSyntheticRepo(t, benchtest.SyntheticRepoConfig{
+		PackageCount: 4,
+		SafeFiles:    1,
+		UsageFiles:   1,
+	})
+	snapshots := benchtest.LoadPackageSnapshots(t, fixture.Root, []string{fixture.RepresentativePackage})
+	if len(snapshots) != 1 {
+		t.Fatalf("expected one representative snapshot, got %d", len(snapshots))
+	}
+
+	cfg := &analyzerConfig{
+		allowlistPath: fixture.AllowlistRelPath,
+		repoRoot:      fixture.Root,
+		roots:         DefaultRoots,
+	}
+
+	originalCollector := repoValidationResultCollector
+	var calls atomic.Int64
+	repoValidationResultCollector = func(repoRoot string, roots []string, allowlist AnyAllowlist) (repoValidationResult, error) {
+		calls.Add(1)
+		return originalCollector(repoRoot, roots, allowlist)
+	}
+	t.Cleanup(func() {
+		repoValidationResultCollector = originalCollector
+	})
+
+	snapshot := snapshots[0]
+	diagnosticCounts := make([]int, 0, 2)
+	for i := 0; i < 2; i++ {
+		diagnosticCount := 0
+		pass := benchtest.NewPass(snapshot, NewAnalyzer(), func(analysis.Diagnostic) {
+			diagnosticCount++
+		})
+
+		if _, err := cfg.run(pass); err != nil {
+			t.Fatalf("run analyzer pass %d: %v", i+1, err)
+		}
+		diagnosticCounts = append(diagnosticCounts, diagnosticCount)
+	}
+
+	if calls.Load() != 1 {
+		t.Fatalf("expected one repo-wide validation run across repeated analyzer passes, got %d", calls.Load())
+	}
+	if len(diagnosticCounts) != 2 || diagnosticCounts[0] == 0 {
+		t.Fatalf("expected repeated analyzer diagnostics, got %#v", diagnosticCounts)
+	}
+	if diagnosticCounts[0] != diagnosticCounts[1] {
+		t.Fatalf("expected stable repeated analyzer diagnostics, got %#v", diagnosticCounts)
+	}
+}


### PR DESCRIPTION
## Summary
- add a process-wide cache for repo-wide analyzer validation keyed by normalized repo root, roots, allowlist fingerprint, and exclude globs
- reuse cached repo-wide validation across analyzer passes while preserving existing diagnostics and stale-selector validation behavior
- add cache normalization/concurrency tests and benchmark coverage for cached vs uncached repeated analyzer runs

Resolves: #40 

## Testing
- go build -v ./...
- go test ./...
- go test -race -v ./...
- go test -bench=. ./...
- go test -bench=. -run=^$ ./...
- golangci-lint run
- bash scripts/ci/run-golangci-plugin-smoke.sh

## Notes
- coverage improved from 74.2% to 75.3%
- BenchmarkAnalyzerRun reused-pass dropped to roughly 1.9-2.1ms/op from roughly 6.7-7.8ms/op for the reset-cache baseline
