### PR TITLE
docs(test,ci): document and verify execution model split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog, with the current development state tracked in the `Unreleased` section at the top.
+
+## [Unreleased]
+
+### Added
+
+- Added corpus coverage for analyzer behavior, allowlist hygiene, explicit boundary cases, safe-slot shadowing, and hot-path benchmarks for validation, analyzer, and module-plugin execution. (@TobyTheHutt)
+- Added execution-model contract tests that distinguish the repo-wide audit path from package-local analyzer and module-plugin diagnostics, including coverage for cached repo-wide stale-selector validation reuse. (@TobyTheHutt)
+- Added focused benchmark commands and smoke-test guidance for analyzer, validation, and golangci-lint plugin paths to make performance regressions easier to catch before release. (@TobyTheHutt)
+
+### Changed
+
+- Formalized the public detection contract around explicit AST slots, exact allowlist selector identity, and the documented differences between anyguard and generic ban-pattern linters. (@TobyTheHutt)
+- Documented upstream-readiness expectations for golangci-lint integration and clarified the slot-resolution contract for supported `any` usage. (@TobyTheHutt)
+- Introduced canonical finding identity and strict v2 allowlist selectors as the stable basis for exact matching and stale-selector rejection. (@TobyTheHutt)
+- Centralized semantic `any` resolution and updated the analyzer to rely on `types.Info` for supported-slot matching instead of bare syntax. (@TobyTheHutt)
+- Cached repo-wide analyzer validation across repeated analyzer passes to avoid unnecessary rescans while preserving repo-wide stale-selector validation. (@TobyTheHutt)
+- Clarified the execution model in the root README and golangci-lint integration docs: CLI, public analyzer, and module plugin runs emit package-local diagnostics, while repo-wide stale-selector validation remains fail-closed across configured roots and is reused once per process. (@TobyTheHutt)
+- Tightened the analyzer internals used by tests so repo-wide validation loading can be observed safely without mutating package-global state. (@TobyTheHutt)
+
+### Fixed
+
+- Guaranteed deterministic ordering across CLI, analyzer, and module-plugin output by sorting findings consistently and preserving stable report order. (@TobyTheHutt)
+- Fail-closed handling now rejects ambiguous analyzer file identity instead of guessing canonical paths. (@TobyTheHutt)
+- Supported-slot matching now resolves `any` semantically against the universe alias across declaration slots and composite compatibility slots, keeping shadowed or user-defined `any` silent. (@TobyTheHutt)
+
+## [1.0.0] - 2026-03-13
+
+### Changed
+
+- Aligned the repository with golangci-lint's new-linter readiness requirements for the `v1.0.0` release. (@TobyTheHutt)
+
+## [0.3.0] - 2026-03-12
+
+### Added
+
+- Exposed a public analyzer API for embedding anyguard into other tools and cleaned up the integration documentation around that public entrypoint. (@TobyTheHutt)
+
+### Changed
+
+- Aligned the documented exit-code behavior with `singlechecker` so CLI expectations match the analyzer-based implementation. (@TobyTheHutt)
+
+## [0.2.0] - 2026-03-11
+
+### Added
+
+- Added golangci-lint module-plugin integration, custom-binary build support, versioned smoke fixtures, and CI coverage for the supported plugin flow. (@TobyTheHutt)
+
+### Changed
+
+- Migrated anyguard from the original standalone guard implementation to a `go/analysis` analyzer, which changed the core integration model for downstream users. (@TobyTheHutt)
+- Simplified test-lint maintenance by removing the `goconst` test exclusion and deduplicating repeated literals. (@TobyTheHutt)
+
+### Fixed
+
+- Hardened custom golangci-lint build steps and pinned compatibility to golangci-lint `v2.7.2` so plugin smoke runs behave predictably in CI. (@TobyTheHutt)
+
+## [0.1.0] - 2026-03-04
+
+### Added
+
+- Initial anyguard release with YAML allowlist support, repository scanning, and CI bootstrap for enforcing controlled `any` usage. (@TobyTheHutt)
+
+[Unreleased]: https://github.com/tobythehutt/anyguard/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/tobythehutt/anyguard/compare/v0.3.0...v1.0.0
+[0.3.0]: https://github.com/tobythehutt/anyguard/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/tobythehutt/anyguard/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/tobythehutt/anyguard/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Go analyzer and CLI that controls where `any` can be used.
 
+Release history lives in [`CHANGELOG.md`](CHANGELOG.md).
+
 ### Why
 
 `any` is useful at boundaries but unchecked usage spreads quickly and weakens type safety.  
@@ -150,11 +152,21 @@ Nested `any` is reportable only when the nested identifier still appears in one 
 - Analyzer files with no filename or no token file are skipped
 - Changing the supported slots above requires an explicit README update because this section is the public compatibility contract
 
+### Execution Model
+
+- Analyzer/plugin path: the CLI (`cmd/anyguard`), public analyzer (`anyguard.NewAnalyzer()`), and golangci-lint module plugin all run as `go/analysis` frontends. Each pass emits diagnostics only for findings in the package currently under analysis.
+- Repo-wide stale-selector validation still happens on that path. Allowlist resolution is built from repo-wide findings across the configured roots, cached once per process, and reused by later analyzer/plugin passes so stale selectors anywhere under those roots still fail closed.
+- Audit path: the repo-wide validation helper used by this repository's tests and benchmarks walks the configured roots once and returns the full repo violation set in a single call. That is the canonical whole-repo audit path.
+- Performance tradeoff: analyzer/plugin execution avoids rescanning the repo for every package pass, but it still pays one repo-wide allowlist-validation cost and, for analyzer/plugin frontends, per-package `typesinfo` loading. The audit path does one full repo walk and is the reference whole-repo measurement path.
+
 ### Development
 
 ```bash
 # Run tests
 go test ./...
+
+# Run focused execution-model contract tests
+go test ./internal/validation -run 'TestValidateAnyUsageAuditsWholeRepo|TestAnalyzerRunUsesRepoWideAllowlistValidation|TestAnalyzerRunReportsPackageLocalDiagnosticsAndReusesRepoValidation'
 
 # Run benchmarks
 go test -bench=. ./...
@@ -162,11 +174,17 @@ go test -bench=. ./...
 # Benchmark only (skip unit tests)
 go test -bench=. -run=^$ ./...
 
+# Run focused perf-sanity benchmarks
+go test -run=^$ -bench='BenchmarkAnalyzerRun|BenchmarkModulePluginSmokePath' -benchtime=1x ./internal/validation ./plugin
+
 # Run lint
 golangci-lint run
+
+# Run the golangci-lint module-plugin smoke test
+bash scripts/ci/run-golangci-plugin-smoke.sh
 ```
 
-The benchmark suite includes `ValidateAnyUsage`, repo-wide finding collection and allowlist resolution helpers, analyzer `Run` in `cold-pass` and `reused-pass` modes, and the golangci-lint module-plugin smoke path.
+The benchmark suite includes `ValidateAnyUsage`, repo-wide finding collection and allowlist resolution helpers, analyzer `Run` in `cold-pass` and `reused-pass` modes, and the golangci-lint module-plugin smoke path. The focused execution-model tests and perf-sanity benchmarks above are the maintainers' contract for package-local analyzer diagnostics plus repo-wide stale-selector validation.
 
 ### golangci-lint integration
 
@@ -178,6 +196,7 @@ The benchmark suite includes `ValidateAnyUsage`, repo-wide finding collection an
 - Plugin name in `.golangci.yml`: `anyguard`
 - Plugin diagnostics follow the same deterministic ordering contract as the CLI and public analyzer.
 - The module plugin requests golangci-lint `typesinfo` load mode so supported-slot matching can use `analysis.Pass.TypesInfo`.
+- The module plugin reports diagnostics for the current package only. Repo-wide allowlist and stale-selector validation are shared across the golangci-lint process and are not redone as a whole-repo audit for every package.
 - Integration docs and examples: `docs/golangci-lint/README.md`
 - Upstream readiness notes: `docs/golangci-lint/README.md#upstream-readiness`
 

--- a/docs/golangci-lint/README.md
+++ b/docs/golangci-lint/README.md
@@ -51,10 +51,19 @@ linters:
 - `roots` (string or list): roots to analyze. Default is `./...`.
 - `repo-root` (string): optional repository root override for path resolution.
 
+## Execution model
+
+- Analyzer/plugin path: golangci-lint loads `anyguard` as a `go/analysis` linter and runs one pass per package. Each pass reports only the findings owned by that package.
+- Repo-wide stale-selector validation still happens in that mode. The allowlist is resolved against repo-wide findings across the configured roots once per golangci-lint process and reused by later package passes.
+- Audit path: the repo-wide validation helper used by this repository's tests and benchmarks walks the configured roots once and returns the full violation set. That is the whole-repo audit reference point; the module plugin does not repeat that work on every package.
+
 ## Load mode and performance
 
 - The module plugin requires `typesinfo` load mode.
 - This increases golangci-lint package loading cost compared with a syntax-only plugin because packages are type checked before `anyguard` runs.
+- The plugin also pays one repo-wide allowlist-validation cost per golangci-lint process so stale selectors remain fail-closed across the configured roots.
+- It does not run a whole-repo diagnostic audit on every package. Only current-package diagnostics are emitted per pass.
+- Compared with the audit path, the tradeoff is higher per-package `typesinfo` loading but no repeated repo scan for every package.
 - Finding identity, allowlist matching, and diagnostic ordering do not change.
 - Measure the repository smoke path with:
 
@@ -62,10 +71,22 @@ linters:
 /usr/bin/time -f 'elapsed=%E maxrss=%MKB' bash scripts/ci/run-golangci-plugin-smoke.sh
 ```
 
+- Run the focused execution-model contract tests with:
+
+```bash
+go test ./internal/validation -run 'TestValidateAnyUsageAuditsWholeRepo|TestAnalyzerRunUsesRepoWideAllowlistValidation|TestAnalyzerRunReportsPackageLocalDiagnosticsAndReusesRepoValidation'
+```
+
 - Measure the local module-plugin benchmark path without building `custom-gcl`:
 
 ```bash
 go test -bench=ModulePluginSmokePath -run=^$ ./plugin
+```
+
+- Run the focused analyzer/plugin perf-sanity benchmarks with:
+
+```bash
+go test -run=^$ -bench='BenchmarkAnalyzerRun|BenchmarkModulePluginSmokePath' -benchtime=1x ./internal/validation ./plugin
 ```
 
 ## Upstream readiness
@@ -75,6 +96,7 @@ For maintainers evaluating possible core inclusion:
 - The normative spec is the root [`Behavior`](../../README.md#behavior), [`Comparison With Generic Ban-Pattern Linters`](../../README.md#comparison-with-generic-ban-pattern-linters), [`Allowlist Schema`](../../README.md#allowlist-schema), and [`Detection Contract`](../../README.md#detection-contract).
 - Supported syntax categories are exactly the AST child slots in the detection contract. Every supported slot resolves the universe `any` alias. The only slots outside dedicated type positions are the three compatibility slots. Anything outside that list is out of scope and intentionally silent.
 - Each finding has one exact identity: `{path, owner, category}`. Allowlist matching is exact on that identity only.
+- Module-plugin execution is package-local for diagnostics, but stale-selector validation remains repo-wide across the configured roots and is reused across package passes in the same process.
 - The analyzer fails closed on unresolved file identity, allowlist parse/validation errors, stale or ambiguous selectors, and traversal or parse failures.
 - CLI, analyzer, and module-plugin reporting order is a compatibility guarantee: no scoring, no heuristic ranking, and stable sort order by `file`, `line`, `column`, `category`, and `owner`.
 - Ordering does not depend on configured root order, filesystem traversal order, or map iteration.

--- a/internal/validation/analyzer.go
+++ b/internal/validation/analyzer.go
@@ -51,9 +51,15 @@ func NewAnalyzer() *analysis.Analyzer {
 }
 
 type analyzerConfig struct {
-	allowlistPath string
-	roots         string
-	repoRoot      string
+	allowlistPath      string
+	roots              string
+	repoRoot           string
+	loadRepoValidation func(
+		repoRoot string,
+		roots []string,
+		allowlist AnyAllowlist,
+		allowlistFingerprint string,
+	) (repoValidationResult, error)
 }
 
 type analyzerFile struct {
@@ -102,13 +108,25 @@ func (cfg *analyzerConfig) run(pass *analysis.Pass) (any, error) {
 
 	// collectAnalyzerFindings builds packageFindings for current-package diagnostics,
 	// while repo-wide validation is cached across analyzer passes in the same process.
-	repoResult, err := loadRepoValidationResult(repoRoot, roots, allowlist, loadedAllowlist.fingerprint)
+	repoResult, err := cfg.loadRepoValidationResult(repoRoot, roots, allowlist, loadedAllowlist.fingerprint)
 	if err != nil {
 		return nil, err
 	}
 
 	reportViolations(pass, collectAnalyzerViolations(files, packageFindings, repoResult.index))
 	return analysisResult{}, nil
+}
+
+func (cfg *analyzerConfig) loadRepoValidationResult(
+	repoRoot string,
+	roots []string,
+	allowlist AnyAllowlist,
+	allowlistFingerprint string,
+) (repoValidationResult, error) {
+	if cfg.loadRepoValidation != nil {
+		return cfg.loadRepoValidation(repoRoot, roots, allowlist, allowlistFingerprint)
+	}
+	return loadRepoValidationResult(repoRoot, roots, allowlist, allowlistFingerprint)
 }
 
 func (cfg *analyzerConfig) resolveRepoRoot(pass *analysis.Pass) (string, error) {

--- a/internal/validation/execution_model_test.go
+++ b/internal/validation/execution_model_test.go
@@ -1,0 +1,136 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/tobythehutt/anyguard/internal/benchtest"
+	"golang.org/x/tools/go/analysis"
+)
+
+const (
+	errValidateAnyUsageFromFile       = "validate any usage from file: %v"
+	errUnexpectedSnapshotCount        = "unexpected package snapshot count: got %d want %d"
+	errExpectedSingleRepoValidation   = "expected one repo-wide validation across package passes, got %d"
+	errUnexpectedPerPackageDiagnostic = "unexpected per-package analyzer diagnostics: got %d want %d"
+	errUnexpectedDiagnosticTotal      = "unexpected analyzer diagnostic total across package passes: got %d want %d"
+)
+
+func TestValidateAnyUsageAuditsWholeRepo(t *testing.T) {
+	fixture := benchtest.CreateSyntheticRepo(t, benchtest.SyntheticRepoConfig{
+		PackageCount: 4,
+		SafeFiles:    1,
+		UsageFiles:   1,
+	})
+
+	violations, err := ValidateAnyUsageFromFile(fixture.AllowlistPath, fixture.Root, fixture.Roots)
+	if err != nil {
+		t.Fatalf(errValidateAnyUsageFromFile, err)
+	}
+	if got, want := len(violations), fixture.ExpectedViolations; got != want {
+		t.Fatalf("unexpected repo-wide audit violation count: got %d want %d", got, want)
+	}
+}
+
+func TestAnalyzerRunUsesRepoWideAllowlistValidation(t *testing.T) {
+	resetProcessRepoValidationCacheForTesting()
+	t.Cleanup(resetProcessRepoValidationCacheForTesting)
+
+	fixture := benchtest.CreateSyntheticRepo(t, benchtest.SyntheticRepoConfig{
+		PackageCount: 4,
+		SafeFiles:    1,
+		UsageFiles:   1,
+	})
+	snapshots := benchtest.LoadPackageSnapshots(t, fixture.Root, fixture.PackagePatterns)
+	if got, want := len(snapshots), fixture.Stats.Packages; got != want {
+		t.Fatalf(errUnexpectedSnapshotCount, got, want)
+	}
+
+	cfg := testSyntheticAnalyzerConfig(fixture)
+	pass := benchtest.NewPass(snapshots[0], NewAnalyzer(), nil)
+	if _, err := cfg.run(pass); err != nil {
+		t.Fatalf("expected repo-wide allowlist validation for analyzer path: %v", err)
+	}
+}
+
+func TestAnalyzerRunReportsPackageLocalDiagnosticsAndReusesRepoValidation(t *testing.T) {
+	resetProcessRepoValidationCacheForTesting()
+	t.Cleanup(resetProcessRepoValidationCacheForTesting)
+
+	fixture := benchtest.CreateSyntheticRepo(t, benchtest.SyntheticRepoConfig{
+		PackageCount: 4,
+		SafeFiles:    1,
+		UsageFiles:   1,
+	})
+	snapshots := benchtest.LoadPackageSnapshots(t, fixture.Root, fixture.PackagePatterns)
+	if got, want := len(snapshots), fixture.Stats.Packages; got != want {
+		t.Fatalf(errUnexpectedSnapshotCount, got, want)
+	}
+
+	auditViolations, err := ValidateAnyUsageFromFile(fixture.AllowlistPath, fixture.Root, fixture.Roots)
+	if err != nil {
+		t.Fatalf(errValidateAnyUsageFromFile, err)
+	}
+
+	if fixture.ExpectedViolations%fixture.Stats.Packages != 0 {
+		t.Fatalf(
+			"expected evenly distributed fixture diagnostics: violations=%d packages=%d",
+			fixture.ExpectedViolations,
+			fixture.Stats.Packages,
+		)
+	}
+	expectedPerPackage := fixture.ExpectedViolations / fixture.Stats.Packages
+
+	cfg := testSyntheticAnalyzerConfig(fixture)
+	var cache repoValidationCache
+	repoValidationCalls := 0
+	cfg.loadRepoValidation = func(
+		repoRoot string,
+		roots []string,
+		allowlist AnyAllowlist,
+		allowlistFingerprint string,
+	) (repoValidationResult, error) {
+		key := newRepoValidationCacheKey(repoRoot, roots, allowlistFingerprint, allowlist.ExcludeGlobs)
+		return cache.load(key, func() (repoValidationResult, error) {
+			repoValidationCalls++
+			return collectRepoValidationResult(repoRoot, roots, allowlist)
+		})
+	}
+
+	totalDiagnostics := 0
+	for _, snapshot := range snapshots {
+		totalDiagnostics += testRunAnalyzerDiagnostics(t, cfg, snapshot)
+	}
+
+	if repoValidationCalls != 1 {
+		t.Fatalf(errExpectedSingleRepoValidation, repoValidationCalls)
+	}
+	// Re-run a representative package after the aggregate pass to assert that
+	// analyzer diagnostics stay package-local and stable independent of cache reuse.
+	if got := testRunAnalyzerDiagnostics(t, cfg, snapshots[0]); got != expectedPerPackage {
+		t.Fatalf(errUnexpectedPerPackageDiagnostic, got, expectedPerPackage)
+	}
+	if got, want := totalDiagnostics, len(auditViolations); got != want {
+		t.Fatalf(errUnexpectedDiagnosticTotal, got, want)
+	}
+}
+
+func testSyntheticAnalyzerConfig(fixture benchtest.SyntheticRepo) *analyzerConfig {
+	return &analyzerConfig{
+		allowlistPath: fixture.AllowlistRelPath,
+		repoRoot:      fixture.Root,
+		roots:         DefaultRoots,
+	}
+}
+
+func testRunAnalyzerDiagnostics(tb testing.TB, cfg *analyzerConfig, snapshot benchtest.PackageSnapshot) int {
+	tb.Helper()
+
+	diagnosticCount := 0
+	pass := benchtest.NewPass(snapshot, NewAnalyzer(), func(analysis.Diagnostic) {
+		diagnosticCount++
+	})
+	if _, err := cfg.run(pass); err != nil {
+		tb.Fatalf("run analyzer: %v", err)
+	}
+	return diagnosticCount
+}


### PR DESCRIPTION
## Summary
- clarify the analyzer/plugin path vs the repo-wide audit path in the root README and golangci-lint docs
- add execution-model contract tests for repo-wide allowlist validation, package-local diagnostics, and cache-backed reuse across package passes
- prepare release-note text for the user-visible behavior clarification

Resolves: #41 

## Testing
- go test ./...
- go test ./internal/validation -run 'TestValidateAnyUsageAuditsWholeRepo|TestAnalyzerRunUsesRepoWideAllowlistValidation|TestAnalyzerRunReportsPackageLocalDiagnosticsAndReusesRepoValidation'
- go test -bench=. ./...
- go test -bench=. -run=^$ ./...
- go test -run=^$ -bench='BenchmarkAnalyzerRun|BenchmarkModulePluginSmokePath' -benchtime=1x ./internal/validation ./plugin
- go test -bench=ModulePluginSmokePath -run=^$ ./plugin
- golangci-lint run
- /usr/bin/time -f 'elapsed=%E maxrss=%MKB' bash scripts/ci/run-golangci-plugin-smoke.sh

## Release Notes
- draft prepared in [docs/release-notes/unreleased.md](/mnt/c/Users/Tobi-Wan/git/me/anyguard/docs/release-notes/unreleased.md)
