### PR TITLE
ci: pin golangci-lint action to v2.7.2

### DIFF
--- a/.github/workflows/golangci-compat.yml
+++ b/.github/workflows/golangci-compat.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Run compatibility checks
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.7.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.7.2
 
   golangci-module-plugin-smoke:
     name: Golangci Module Plugin Smoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on Keep a Changelog, with the current development state trac
 
 ### Fixed
 
+- Pinned all CI `golangci-lint-action` runs to golangci-lint `v2.7.2` so local, plugin-smoke, and workflow lint behavior stay reproducible across the repository. (@TobyTheHutt)
 - Guaranteed deterministic ordering across CLI, analyzer, and module-plugin output by sorting findings consistently and preserving stable report order. (@TobyTheHutt)
 - Fail-closed handling now rejects ambiguous analyzer file identity instead of guessing canonical paths. (@TobyTheHutt)
 - Supported-slot matching now resolves `any` semantically against the universe alias across declaration slots and composite compatibility slots, keeping shadowed or user-defined `any` silent. (@TobyTheHutt)


### PR DESCRIPTION
## Summary

Pin `golangci-lint-action` to `v2.7.2` in CI so workflow lint and compatibility runs match the already-pinned local/plugin smoke paths.

Resolves: #44 

## Changes

- replace `version: latest` with `version: v2.7.2` in `.github/workflows/test.yml`
- replace `version: latest` with `version: v2.7.2` in `.github/workflows/golangci-compat.yml`
- add an unreleased changelog entry for the CI reproducibility fix

## Impact

CI now uses the same pinned `golangci-lint` version as the custom plugin configs and module-plugin smoke path, removing version drift and making lint/compat failures reproducible.
