### PR TITLE
docs(release): Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog, with the current development state tracked in the `Unreleased` section at the top.
 
 ## [Unreleased]
+## [2.0.0] - 2026-03-22
 
 ### Added
 
@@ -66,7 +67,8 @@ The format is based on Keep a Changelog, with the current development state trac
 
 - Initial anyguard release with YAML allowlist support, repository scanning, and CI bootstrap for enforcing controlled `any` usage. (@TobyTheHutt)
 
-[Unreleased]: https://github.com/tobythehutt/anyguard/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/tobythehutt/anyguard/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/tobythehutt/anyguard/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/tobythehutt/anyguard/compare/v0.3.0...v1.0.0
 [0.3.0]: https://github.com/tobythehutt/anyguard/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/tobythehutt/anyguard/compare/v0.1.0...v0.2.0

--- a/docs/golangci-lint/.custom-gcl.yml
+++ b/docs/golangci-lint/.custom-gcl.yml
@@ -4,4 +4,4 @@ name: custom-gcl
 plugins:
   - module: github.com/tobythehutt/anyguard
     import: github.com/tobythehutt/anyguard/plugin
-    version: v1.0.0
+    version: v2.0.0

--- a/docs/golangci-lint/README.md
+++ b/docs/golangci-lint/README.md
@@ -114,7 +114,6 @@ For maintainers evaluating possible core inclusion:
 
 ## Release and version pinning
 
-- Keep `plugins[].version` pinned to a released tag such as `v1.0.0`.
-- Update the pinned version only after a corresponding module tag/release is published.
+- Keep `plugins[].version` pinned to the tag being released, for example `v2.0.0`.
 - Module plugin support starts with `v1.0.0`. Do not pin below this version.
 - The plugin entrypoint import path `github.com/tobythehutt/anyguard/plugin` is stable and versioned with module tags.

--- a/testdata/golangci/.custom-gcl.yml
+++ b/testdata/golangci/.custom-gcl.yml
@@ -3,4 +3,4 @@ name: custom-gcl
 plugins:
   - module: github.com/tobythehutt/anyguard
     import: github.com/tobythehutt/anyguard/plugin
-    version: v1.0.0
+    version: v2.0.0


### PR DESCRIPTION
## Summary
- move the unreleased changelog entries into the dated v2.0.0 section
- update changelog comparison links for the v2.0.0 release line
- pin the golangci-lint module-plugin example and smoke fixture to v2.0.0

Resolves: #48 