### PR TITLE
fix(validation): honor Go build constraints in repo-wide audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog, with the current development state tracked in the `Unreleased` section at the top.
 
 ## [Unreleased]
+
+### Fixed
+
+- Aligned repo-wide audit file discovery with the active Go build context so inactive `//go:build`, `GOOS`, `GOARCH`, file-suffixed, and cgo-gated files no longer create stale-selector or violation mismatches versus analyzer and plugin runs. (@TobyTheHutt)
+
 ## [2.0.0] - 2026-03-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Nested `any` is reportable only when the nested identifier still appears in one 
 
 - Analyzer/plugin path: the CLI (`cmd/anyguard`), public analyzer (`anyguard.NewAnalyzer()`), and golangci-lint module plugin all run as `go/analysis` frontends. Each pass emits diagnostics only for findings in the package currently under analysis.
 - Repo-wide stale-selector validation still happens on that path. Allowlist resolution is built from repo-wide findings across the configured roots, cached once per process, and reused by later analyzer/plugin passes so stale selectors anywhere under those roots still fail closed.
-- Audit path: the repo-wide validation helper used by this repository's tests and benchmarks walks the configured roots once and returns the full repo violation set in a single call. That is the canonical whole-repo audit path.
+- Audit path: the repo-wide validation helper used by this repository's tests and benchmarks walks the configured roots once, applies the active Go build context (`//go:build`, `GOOS`, `GOARCH`, file suffix constraints, and `CGO_ENABLED`), and returns the full repo violation set in a single call. That is the canonical whole-repo audit path.
 - Performance tradeoff: analyzer/plugin execution avoids rescanning the repo for every package pass, but it still pays one repo-wide allowlist-validation cost and, for analyzer/plugin frontends, per-package `typesinfo` loading. The audit path does one full repo walk and is the reference whole-repo measurement path.
 
 ### Development

--- a/docs/golangci-lint/README.md
+++ b/docs/golangci-lint/README.md
@@ -55,7 +55,7 @@ linters:
 
 - Analyzer/plugin path: golangci-lint loads `anyguard` as a `go/analysis` linter and runs one pass per package. Each pass reports only the findings owned by that package.
 - Repo-wide stale-selector validation still happens in that mode. The allowlist is resolved against repo-wide findings across the configured roots once per golangci-lint process and reused by later package passes.
-- Audit path: the repo-wide validation helper used by this repository's tests and benchmarks walks the configured roots once and returns the full violation set. That is the whole-repo audit reference point; the module plugin does not repeat that work on every package.
+- Audit path: the repo-wide validation helper used by this repository's tests and benchmarks walks the configured roots once, applies the active Go build context (`//go:build`, `GOOS`, `GOARCH`, file suffix constraints, and `CGO_ENABLED`), and returns the full violation set. That is the whole-repo audit reference point; the module plugin does not repeat that work on every package.
 
 ## Load mode and performance
 

--- a/internal/validation/any_usage.go
+++ b/internal/validation/any_usage.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
+	"go/build"
 	"go/importer"
 	"go/parser"
 	"go/token"
@@ -31,6 +32,9 @@ const (
 	anyTokenMarker      = "<<ANY>>"
 	anyName             = "any"
 	sourceImporterMode  = "source"
+	goosEnvVar          = "GOOS"
+	goarchEnvVar        = "GOARCH"
+	cgoEnabledEnvVar    = "CGO_ENABLED"
 )
 
 var nolintDirectiveRE = regexp.MustCompile(`(?i)\bnolint(?::([a-z0-9_,-]+))?`)
@@ -250,8 +254,9 @@ type parsedPackage struct {
 func collectParsedPackages(rootPath, baseAbs string, globs []string) (parsedPackageCollection, error) {
 	fset := token.NewFileSet()
 	grouped := make(map[parsedPackageKey]*parsedPackage)
+	buildCtx := currentBuildContext()
 
-	err := walkParsedFiles(rootPath, baseAbs, globs, fset, func(file parsedGoFile) error {
+	err := walkParsedFiles(rootPath, baseAbs, globs, fset, buildCtx, func(file parsedGoFile) error {
 		appendParsedPackageFile(grouped, file)
 		return nil
 	})
@@ -266,10 +271,11 @@ func walkParsedFiles(
 	rootPath, baseAbs string,
 	globs []string,
 	fset *token.FileSet,
+	buildCtx *build.Context,
 	visit func(parsedGoFile) error,
 ) error {
 	return filepath.WalkDir(rootPath, func(path string, entry fs.DirEntry, walkErr error) error {
-		parsedFile, keep, err := parseRootFile(fset, path, entry, walkErr, baseAbs, globs)
+		parsedFile, keep, err := parseRootFile(fset, path, entry, walkErr, baseAbs, globs, buildCtx)
 		if err != nil {
 			return err
 		}
@@ -328,6 +334,7 @@ func parseRootFile(
 	walkErr error,
 	baseAbs string,
 	globs []string,
+	buildCtx *build.Context,
 ) (parsedGoFile, bool, error) {
 	if walkErr != nil {
 		return parsedGoFile{}, false, walkErr
@@ -342,6 +349,13 @@ func parseRootFile(
 	}
 	relPath = normalizePath(relPath)
 	if shouldExclude(relPath, globs) {
+		return parsedGoFile{}, false, nil
+	}
+	keepForBuild, err := buildCtx.MatchFile(filepath.Dir(path), filepath.Base(path))
+	if err != nil {
+		return parsedGoFile{}, false, fmt.Errorf("match build constraints for %s: %w", relPath, err)
+	}
+	if !keepForBuild {
 		return parsedGoFile{}, false, nil
 	}
 
@@ -361,6 +375,23 @@ func parseRootFile(
 		content: content,
 		syntax:  syntax,
 	}, true, nil
+}
+
+func currentBuildContext() *build.Context {
+	ctx := build.Default
+	if goos := strings.TrimSpace(os.Getenv(goosEnvVar)); goos != "" {
+		ctx.GOOS = goos
+	}
+	if goarch := strings.TrimSpace(os.Getenv(goarchEnvVar)); goarch != "" {
+		ctx.GOARCH = goarch
+	}
+	switch strings.TrimSpace(os.Getenv(cgoEnabledEnvVar)) {
+	case "0":
+		ctx.CgoEnabled = false
+	case "1":
+		ctx.CgoEnabled = true
+	}
+	return &ctx
 }
 
 func newParsedPackageKey(file parsedGoFile) parsedPackageKey {

--- a/internal/validation/any_usage_test.go
+++ b/internal/validation/any_usage_test.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"go/ast"
+	"go/build"
 	"go/importer"
 	"go/parser"
 	"go/token"
@@ -21,6 +22,10 @@ const (
 	testDirAPI                 = "api"
 	testRootAPI                = "pkg/api"
 	testPayloadPath            = "pkg/api/payload.go"
+	testLinuxOKFile            = "linux_ok.go"
+	testPayloadWindowsFile     = "payload_windows.go"
+	testPayloadAMD64File       = "payload_amd64.go"
+	testSafeSource             = "package api\ntype Safe struct{ Value string }\n"
 	testPayloadFile            = "payload.go"
 	testAllowlistFile          = "allowlist.yaml"
 	testPayloadBoundaryDesc    = "payload boundary"
@@ -50,6 +55,10 @@ const (
 	testExpectedNormalizeRoots = "."
 	testUnexpectedDeclUsages   = "unexpected declaration-slot usages:\ngot: %#v\nwant: %#v"
 	testUnexpectedCompUsages   = "unexpected composite-slot usages:\ngot: %#v\nwant: %#v"
+	testGOOSLinux              = "linux"
+	testGOOSWindows            = "windows"
+	testGOARCHAMD64            = "amd64"
+	testGOARCHARM64            = "arm64"
 )
 
 func TestLoadAnyAllowlistErrors(t *testing.T) {
@@ -198,6 +207,49 @@ func TestValidateAnyUsageHandlesExcludesAndRoots(t *testing.T) {
 	if violations[0].File != testPayloadPath {
 		t.Fatalf("unexpected file in violation: %q", violations[0].File)
 	}
+}
+
+func TestValidateAnyUsageSkipsInactiveBuildTaggedFiles(t *testing.T) {
+	base := t.TempDir()
+	windowsOnlyPath := normalizePath(filepath.Join(testRootAPI, "windows_only.go"))
+
+	writeFile(t, apiPath(base, testLinuxOKFile), testSafeSource)
+	writeFile(t, filepath.Join(base, windowsOnlyPath), "//go:build windows\n\npackage api\n\ntype Payload map[string]any\n")
+
+	assertBuildContextViolations(t, base, buildEnv{goos: testGOOSLinux, goarch: testGOARCHAMD64}, nil)
+
+	want := []violationSummary{
+		{file: windowsOnlyPath, owner: testOwnerPayload, category: string(anyCategoryMapTypeValue), line: 5, column: 25},
+	}
+	assertBuildContextViolations(t, base, buildEnv{goos: testGOOSWindows, goarch: testGOARCHAMD64}, want)
+}
+
+func TestValidateAnyUsageSkipsInactiveGOOSFiles(t *testing.T) {
+	base := t.TempDir()
+	windowsPath := normalizePath(filepath.Join(testRootAPI, testPayloadWindowsFile))
+
+	writeFile(t, apiPath(base, testLinuxOKFile), testSafeSource)
+	writeFile(t, filepath.Join(base, windowsPath), testPayloadSource)
+
+	want := []violationSummary{
+		{file: windowsPath, owner: testOwnerPayload, category: string(anyCategoryMapTypeValue), line: 2, column: 25},
+	}
+	assertBuildContextViolations(t, base, buildEnv{goos: testGOOSLinux, goarch: testGOARCHAMD64}, nil)
+	assertBuildContextViolations(t, base, buildEnv{goos: testGOOSWindows, goarch: testGOARCHAMD64}, want)
+}
+
+func TestValidateAnyUsageSkipsInactiveGOARCHFiles(t *testing.T) {
+	base := t.TempDir()
+	amd64Path := normalizePath(filepath.Join(testRootAPI, testPayloadAMD64File))
+
+	writeFile(t, apiPath(base, "safe.go"), testSafeSource)
+	writeFile(t, filepath.Join(base, amd64Path), testPayloadSource)
+
+	want := []violationSummary{
+		{file: amd64Path, owner: testOwnerPayload, category: string(anyCategoryMapTypeValue), line: 2, column: 25},
+	}
+	assertBuildContextViolations(t, base, buildEnv{goos: testGOOSLinux, goarch: testGOARCHARM64}, nil)
+	assertBuildContextViolations(t, base, buildEnv{goos: testGOOSLinux, goarch: testGOARCHAMD64}, want)
 }
 
 func TestValidateAnyUsageAllowsTypeParamConstraint(t *testing.T) {
@@ -1394,7 +1446,7 @@ func TestParseRootFileSkipsDirectory(t *testing.T) {
 	fset := token.NewFileSet()
 	entry := dirEntryFromPath(t, base)
 
-	_, keep, err := parseRootFile(fset, base, entry, nil, base, nil)
+	_, keep, err := parseRootFile(fset, base, entry, nil, base, nil, currentBuildContext())
 	if err != nil {
 		t.Fatalf("parse directory: %v", err)
 	}
@@ -1410,12 +1462,28 @@ func TestParseRootFileSkipsExcludedFile(t *testing.T) {
 	writeFile(t, path, testPackageAPISource)
 	entry := dirEntryFromPath(t, path)
 
-	_, keep, err := parseRootFile(fset, path, entry, nil, base, []string{"**/*_test.go"})
+	_, keep, err := parseRootFile(fset, path, entry, nil, base, []string{"**/*_test.go"}, currentBuildContext())
 	if err != nil {
 		t.Fatalf("parse excluded file: %v", err)
 	}
 	if keep {
 		t.Fatalf("expected excluded file to be skipped")
+	}
+}
+
+func TestParseRootFileSkipsInactiveBuildConstrainedFile(t *testing.T) {
+	base := t.TempDir()
+	fset := token.NewFileSet()
+	path := filepath.Join(base, testRootAPI, "payload_windows.go")
+	writeFile(t, path, testPayloadSource)
+	entry := dirEntryFromPath(t, path)
+
+	_, keep, err := parseRootFile(fset, path, entry, nil, base, nil, testBuildContext("linux", "amd64"))
+	if err != nil {
+		t.Fatalf("parse inactive build-constrained file: %v", err)
+	}
+	if keep {
+		t.Fatalf("expected inactive build-constrained file to be skipped")
 	}
 }
 
@@ -1426,7 +1494,7 @@ func TestParseRootFileReportsParseErrors(t *testing.T) {
 	writeFile(t, path, testBrokenGoSource)
 	entry := dirEntryFromPath(t, path)
 
-	_, keep, err := parseRootFile(fset, path, entry, nil, base, nil)
+	_, keep, err := parseRootFile(fset, path, entry, nil, base, nil, currentBuildContext())
 	if err == nil {
 		t.Fatal(testExpectedParseError)
 	}
@@ -1442,7 +1510,7 @@ func TestParseRootFileReturnsParsedGoFile(t *testing.T) {
 	writeFile(t, path, testPayloadSource)
 	entry := dirEntryFromPath(t, path)
 
-	parsed, keep, err := parseRootFile(fset, path, entry, nil, base, nil)
+	parsed, keep, err := parseRootFile(fset, path, entry, nil, base, nil, currentBuildContext())
 	if err != nil {
 		t.Fatalf(testParseFileErrFmt, err)
 	}
@@ -1586,6 +1654,12 @@ type usageSummary struct {
 	category anyUsageCategory
 	owner    string
 	line     int
+}
+
+type buildEnv struct {
+	goos       string
+	goarch     string
+	cgoEnabled string
 }
 
 type violationSummary struct {
@@ -1750,4 +1824,75 @@ func writeFile(t *testing.T, path, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write file: %v", err)
 	}
+}
+
+func assertBuildContextViolations(t *testing.T, base string, env buildEnv, want []violationSummary) {
+	t.Helper()
+
+	applyBuildEnv(t, env)
+
+	violations, err := ValidateAnyUsage(AnyAllowlist{Version: anyAllowlistVersion}, base, []string{testRootAPI})
+	if err != nil {
+		t.Fatalf(testValidateUsageErrFmt, err)
+	}
+	got := collectViolationSummaries(violations)
+	if want == nil {
+		want = []violationSummary{}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected build-context violations for GOOS=%q GOARCH=%q:\ngot: %#v\nwant: %#v", env.goos, env.goarch, got, want)
+	}
+}
+
+func TestCurrentBuildContextRespectsCGOEnabledEnv(t *testing.T) {
+	testCases := []struct {
+		name string
+		env  buildEnv
+		want bool
+	}{
+		{
+			name: "default",
+			env:  buildEnv{},
+			want: build.Default.CgoEnabled,
+		},
+		{
+			name: "disabled",
+			env:  buildEnv{cgoEnabled: "0"},
+			want: false,
+		},
+		{
+			name: "enabled",
+			env:  buildEnv{cgoEnabled: "1"},
+			want: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			applyBuildEnv(t, testCase.env)
+
+			if got := currentBuildContext().CgoEnabled; got != testCase.want {
+				t.Fatalf("unexpected cgo enabled state: got %t want %t", got, testCase.want)
+			}
+		})
+	}
+}
+
+func applyBuildEnv(t *testing.T, env buildEnv) {
+	t.Helper()
+
+	t.Setenv(goosEnvVar, env.goos)
+	t.Setenv(goarchEnvVar, env.goarch)
+	t.Setenv(cgoEnabledEnvVar, env.cgoEnabled)
+}
+
+func testBuildContext(goos, goarch string) *build.Context {
+	ctx := build.Default
+	if goos != "" {
+		ctx.GOOS = goos
+	}
+	if goarch != "" {
+		ctx.GOARCH = goarch
+	}
+	return &ctx
 }


### PR DESCRIPTION
## Summary

- make repo-wide validation skip files that are inactive for the current Go build context
- align whole-repo audit behavior with analyzer and module-plugin behavior for `//go:build`, `GOOS`, `GOARCH`, file suffix constraints, and `CGO_ENABLED`
- add regression coverage for build-tagged, GOOS-specific, GOARCH-specific, and cgo-env cases
- document the audit-path build-context behavior in the README and golangci-lint docs

## Testing

- `go test ./...`
- `go test ./internal/validation -run 'TestValidateAnyUsageAuditsWholeRepo|TestAnalyzerRunUsesRepoWideAllowlistValidation|TestAnalyzerRunReportsPackageLocalDiagnosticsAndReusesRepoValidation'`
- `go test -bench=. ./...`
- `go test -bench=. -run=^$ ./...`
- `go test -run=^$ -bench='BenchmarkAnalyzerRun|BenchmarkModulePluginSmokePath' -benchtime=1x ./internal/validation ./plugin`
- `golangci-lint run`
- `bash scripts/ci/run-golangci-plugin-smoke.sh`

## Notes

- total coverage improved from `75.4%` to `75.7%`
- the golangci smoke script still reports the expected 5 fixture diagnostics and exits successfully
