### PR TITLE
fix: honor exclude globs in analyzer diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog, with the current development state trac
 ### Fixed
 
 - Aligned repo-wide audit file discovery with the active Go build context so inactive `//go:build`, `GOOS`, `GOARCH`, file-suffixed, and cgo-gated files no longer create stale-selector or violation mismatches versus analyzer and plugin runs. (@TobyTheHutt)
+- Honored `exclude_globs` on the analyzer, CLI, and golangci-lint package-local diagnostic path so those frontends now use the same repository-relative file set as repo-wide allowlist resolution. (@TobyTheHutt)
 
 ## [2.0.0] - 2026-03-22
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Nested `any` is reportable only when the nested identifier still appears in one 
 
 ### Execution Model
 
-- Analyzer/plugin path: the CLI (`cmd/anyguard`), public analyzer (`anyguard.NewAnalyzer()`), and golangci-lint module plugin all run as `go/analysis` frontends. Each pass emits diagnostics only for findings in the package currently under analysis.
+- Analyzer/plugin path: the CLI (`cmd/anyguard`), public analyzer (`anyguard.NewAnalyzer()`), and golangci-lint module plugin all run as `go/analysis` frontends. Each pass emits diagnostics only for findings in the package currently under analysis after applying the configured roots and `exclude_globs` to the same canonical repository-relative file identities used by repo-wide allowlist resolution.
 - Repo-wide stale-selector validation still happens on that path. Allowlist resolution is built from repo-wide findings across the configured roots, cached once per process, and reused by later analyzer/plugin passes so stale selectors anywhere under those roots still fail closed.
 - Audit path: the repo-wide validation helper used by this repository's tests and benchmarks walks the configured roots once, applies the active Go build context (`//go:build`, `GOOS`, `GOARCH`, file suffix constraints, and `CGO_ENABLED`), and returns the full repo violation set in a single call. That is the canonical whole-repo audit path.
 - Performance tradeoff: analyzer/plugin execution avoids rescanning the repo for every package pass, but it still pays one repo-wide allowlist-validation cost and, for analyzer/plugin frontends, per-package `typesinfo` loading. The audit path does one full repo walk and is the reference whole-repo measurement path.

--- a/docs/golangci-lint/README.md
+++ b/docs/golangci-lint/README.md
@@ -53,7 +53,7 @@ linters:
 
 ## Execution model
 
-- Analyzer/plugin path: golangci-lint loads `anyguard` as a `go/analysis` linter and runs one pass per package. Each pass reports only the findings owned by that package.
+- Analyzer/plugin path: golangci-lint loads `anyguard` as a `go/analysis` linter and runs one pass per package. Each pass reports only the findings owned by that package after applying the configured roots and `exclude_globs` to the same canonical repository-relative file identities used by repo-wide allowlist resolution.
 - Repo-wide stale-selector validation still happens in that mode. The allowlist is resolved against repo-wide findings across the configured roots once per golangci-lint process and reused by later package passes.
 - Audit path: the repo-wide validation helper used by this repository's tests and benchmarks walks the configured roots once, applies the active Go build context (`//go:build`, `GOOS`, `GOARCH`, file suffix constraints, and `CGO_ENABLED`), and returns the full violation set. That is the whole-repo audit reference point; the module plugin does not repeat that work on every package.
 

--- a/internal/validation/analyzer.go
+++ b/internal/validation/analyzer.go
@@ -97,7 +97,7 @@ func (cfg *analyzerConfig) run(pass *analysis.Pass) (any, error) {
 	}
 	allowlist := loadedAllowlist.allowlist
 
-	files, err := collectAnalyzerFiles(pass, repoRoot, roots)
+	files, err := collectAnalyzerFiles(pass, repoRoot, roots, allowlist.ExcludeGlobs)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func resolveAllowlistPath(repoRoot, configured string) (string, error) {
 	return abs, nil
 }
 
-func collectAnalyzerFiles(pass *analysis.Pass, repoRoot string, roots []string) ([]analyzerFile, error) {
+func collectAnalyzerFiles(pass *analysis.Pass, repoRoot string, roots []string, excludeGlobs []string) ([]analyzerFile, error) {
 	filteredRoots := normalizeConfiguredRoots(roots, repoRoot)
 	if len(filteredRoots) == 0 {
 		return nil, errors.New("no usable roots after normalization")
@@ -201,36 +201,56 @@ func collectAnalyzerFiles(pass *analysis.Pass, repoRoot string, roots []string) 
 
 	files := make([]analyzerFile, 0, len(pass.Files))
 	for _, file := range pass.Files {
-		pos := pass.Fset.PositionFor(file.Package, false)
-		if pos.Filename == "" {
-			continue
-		}
-
-		relPath, err := relativePath(repoRoot, pos.Filename)
+		collected, keep, err := collectAnalyzerFile(pass, file, repoRoot, filteredRoots, excludeGlobs)
 		if err != nil {
-			return nil, fmt.Errorf("compute relative path for %s: %w", pos.Filename, err)
+			return nil, err
 		}
-		if !isWithinRoots(relPath, filteredRoots) {
-			continue
+		if keep {
+			files = append(files, collected)
 		}
-
-		tokenFile := pass.Fset.File(file.Package)
-		if tokenFile == nil {
-			continue
-		}
-
-		content, err := readAnalyzerFile(pass, pos.Filename)
-		if err != nil {
-			return nil, fmt.Errorf("read analyzer file %s: %w", pos.Filename, err)
-		}
-		files = append(files, analyzerFile{
-			content:   content,
-			relPath:   relPath,
-			syntax:    file,
-			tokenFile: tokenFile,
-		})
 	}
 	return files, nil
+}
+
+func collectAnalyzerFile(
+	pass *analysis.Pass,
+	file *ast.File,
+	repoRoot string,
+	roots []string,
+	excludeGlobs []string,
+) (analyzerFile, bool, error) {
+	pos := pass.Fset.PositionFor(file.Package, false)
+	if pos.Filename == "" {
+		return analyzerFile{}, false, nil
+	}
+
+	relPath, err := relativePath(repoRoot, pos.Filename)
+	if err != nil {
+		return analyzerFile{}, false, fmt.Errorf("compute relative path for %s: %w", pos.Filename, err)
+	}
+	if !shouldCollectAnalyzerPath(relPath, roots, excludeGlobs) {
+		return analyzerFile{}, false, nil
+	}
+
+	tokenFile := pass.Fset.File(file.Package)
+	if tokenFile == nil {
+		return analyzerFile{}, false, nil
+	}
+
+	content, err := readAnalyzerFile(pass, pos.Filename)
+	if err != nil {
+		return analyzerFile{}, false, fmt.Errorf("read analyzer file %s: %w", pos.Filename, err)
+	}
+	return analyzerFile{
+		content:   content,
+		relPath:   relPath,
+		syntax:    file,
+		tokenFile: tokenFile,
+	}, true, nil
+}
+
+func shouldCollectAnalyzerPath(relPath string, roots []string, excludeGlobs []string) bool {
+	return isWithinRoots(relPath, roots) && !shouldExclude(relPath, excludeGlobs)
 }
 
 func readAnalyzerFile(pass *analysis.Pass, filename string) ([]byte, error) {

--- a/internal/validation/analyzer_test.go
+++ b/internal/validation/analyzer_test.go
@@ -18,8 +18,10 @@ const (
 	testdataSrcDir     = "src"
 	testAllowlistPath  = "allowlist.yaml"
 	testAllowlistEmpty = "allowlist-empty.yaml"
+	testAllowlistExcl  = "allowlist-excluded.yaml"
 	testPkgViolations  = "violations"
 	testPkgAllowed     = "allowed"
+	testPkgExcluded    = "generated"
 	testPkgFiltered    = "filtered"
 	testPkgDir         = "pkg"
 	testNilPkgPath     = "pkg/nilpkg.go"
@@ -58,6 +60,18 @@ func TestAnalyzerRespectsRoots(t *testing.T) {
 	analysistest.Run(t, testdata, analyzer, testPkgFiltered)
 }
 
+func TestAnalyzerHonorsExcludeGlobs(t *testing.T) {
+	analyzer := NewAnalyzer()
+	testdata := analysistest.TestData()
+	repoRoot := filepath.Join(testdata, testdataSrcDir)
+
+	setAnalyzerFlag(t, analyzer, flagAllowlist, filepath.Join(testdata, testAllowlistExcl))
+	setAnalyzerFlag(t, analyzer, flagRepoRoot, repoRoot)
+	setAnalyzerFlag(t, analyzer, flagRoots, DefaultRoots)
+
+	analysistest.Run(t, testdata, analyzer, testPkgExcluded)
+}
+
 func TestNewAnalyzerRunsDespiteErrors(t *testing.T) {
 	analyzer := NewAnalyzer()
 	if !analyzer.RunDespiteErrors {
@@ -86,7 +100,7 @@ func TestCollectAnalyzerFilesWithNilPackage(t *testing.T) {
 		Files: []*ast.File{parsed},
 	}
 
-	files, err := collectAnalyzerFiles(pass, base, []string{DefaultRoots})
+	files, err := collectAnalyzerFiles(pass, base, []string{DefaultRoots}, nil)
 	if err != nil {
 		t.Fatalf(testCollectFiles, err)
 	}
@@ -119,7 +133,7 @@ func TestCollectAnalyzerFilesUsesPassReadFile(t *testing.T) {
 		},
 	}
 
-	files, err := collectAnalyzerFiles(pass, base, []string{DefaultRoots})
+	files, err := collectAnalyzerFiles(pass, base, []string{DefaultRoots}, nil)
 	if err != nil {
 		t.Fatalf(testCollectFiles, err)
 	}
@@ -157,7 +171,7 @@ func TestCollectAnalyzerFindingsUsesPassTypesInfo(t *testing.T) {
 		TypesInfo: typeCheckTestFile(fset, parsed),
 	}
 
-	files, err := collectAnalyzerFiles(pass, base, []string{DefaultRoots})
+	files, err := collectAnalyzerFiles(pass, base, []string{DefaultRoots}, nil)
 	if err != nil {
 		t.Fatalf(testCollectFiles, err)
 	}
@@ -192,7 +206,7 @@ func TestCollectAnalyzerFindingsRequiresTypesInfo(t *testing.T) {
 		Files: []*ast.File{parsed},
 	}
 
-	files, err := collectAnalyzerFiles(pass, base, []string{DefaultRoots})
+	files, err := collectAnalyzerFiles(pass, base, []string{DefaultRoots}, nil)
 	if err != nil {
 		t.Fatalf(testCollectFiles, err)
 	}
@@ -203,6 +217,36 @@ func TestCollectAnalyzerFindingsRequiresTypesInfo(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), errMissingTypesInfo) {
 		t.Fatalf(testUnexpectedErr, err)
+	}
+}
+
+func TestCollectAnalyzerFilesHonorsExcludeGlobs(t *testing.T) {
+	base := t.TempDir()
+	sourcePath := filepath.Join(base, testPkgDir, "generated", "payload.go")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o750); err != nil {
+		t.Fatalf(testCreateSource, err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(testAnalyzerSrc), 0o600); err != nil {
+		t.Fatalf(testWriteSource, err)
+	}
+
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, sourcePath, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf(testParseSource, err)
+	}
+
+	pass := &analysis.Pass{
+		Fset:  fset,
+		Files: []*ast.File{parsed},
+	}
+
+	files, err := collectAnalyzerFiles(pass, base, []string{DefaultRoots}, []string{"pkg/generated/**"})
+	if err != nil {
+		t.Fatalf(testCollectFiles, err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected excluded analyzer file set to stay empty, got %d files", len(files))
 	}
 }
 
@@ -306,7 +350,7 @@ func TestCollectAnalyzerFilesRejectsAmbiguousIdentity(t *testing.T) {
 		Files: []*ast.File{parsed},
 	}
 
-	_, err = collectAnalyzerFiles(pass, repoRoot, []string{DefaultRoots})
+	_, err = collectAnalyzerFiles(pass, repoRoot, []string{DefaultRoots}, nil)
 	if err == nil {
 		t.Fatalf("expected canonical path resolution error")
 	}

--- a/internal/validation/testdata/allowlist-excluded.yaml
+++ b/internal/validation/testdata/allowlist-excluded.yaml
@@ -1,0 +1,4 @@
+version: 2
+exclude_globs:
+  - "generated/**"
+entries: []

--- a/internal/validation/testdata/src/generated/generated.go
+++ b/internal/validation/testdata/src/generated/generated.go
@@ -1,0 +1,3 @@
+package generated
+
+type Payload map[string]any


### PR DESCRIPTION
## Summary

- honor `exclude_globs` in analyzer/package-local file collection
- keep analyzer, CLI, golangci-lint, and repo-wide validation on the same repo-relative file set
- add analyzer regression coverage and clarify the execution-model docs

Resolves: #53 

## Testing

- `go test ./...`
- `go test ./internal/validation -run 'TestValidateAnyUsageAuditsWholeRepo|TestAnalyzerRunUsesRepoWideAllowlistValidation|TestAnalyzerRunReportsPackageLocalDiagnosticsAndReusesRepoValidation'`
- `go test -bench=. ./...`
- `go test -bench=. -run=^$ ./...`
- `go test -bench=ModulePluginSmokePath -run=^$ ./plugin`
- `go test -run=^$ -bench='BenchmarkAnalyzerRun|BenchmarkModulePluginSmokePath' -benchtime=1x ./internal/validation ./plugin`
- `golangci-lint run`
- `bash scripts/ci/run-golangci-plugin-smoke.sh`

## Notes

- verified the reported CLI repro now stays silent for files matched by `exclude_globs`
- coverage increased from `75.7%` to `75.9%`
