### PR TITLE
fix(validation): make allowlist selector identity collision-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog, with the current development state trac
 
 ### Fixed
 
+- Tightened canonical finding identity with exact `line` and `column` coordinates so one allowlist entry can no longer silently suppress multiple same-file, same-owner, same-category findings. Legacy three-field selectors now resolve only when unique and otherwise fail closed as ambiguous. (@TobyTheHutt)
 - Aligned repo-wide audit file discovery with the active Go build context so inactive `//go:build`, `GOOS`, `GOARCH`, file-suffixed, and cgo-gated files no longer create stale-selector or violation mismatches versus analyzer and plugin runs. (@TobyTheHutt)
 - Honored `exclude_globs` on the analyzer, CLI, and golangci-lint package-local diagnostic path so those frontends now use the same repository-relative file set as repo-wide allowlist resolution. (@TobyTheHutt)
 - Skipped synthetic `go test` main files outside `repoRoot` on the analyzer, CLI, and singlechecker path so `./...` stays stable on normal modules with `_test.go` files while real repo files still fail closed on ambiguous identity. (@TobyTheHutt)

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Packages:
 | Concern | Generic ban-pattern linter | `anyguard` |
 | --- | --- | --- |
 | Basic overlap | Usually bans an identifier, token, or textual pattern and reports matches. | Reports `any` only in explicitly supported AST child slots, and every supported slot resolves the universe `any` alias so shadowed declarations stay silent. The dedicated type-position slots are semantically resolved, and `*ast.CallExpr.Fun`, `*ast.IndexExpr.Index`, and `*ast.IndexListExpr.Indices[i]` remain deliberate compatibility slots for conversions and generic instantiations. |
-| Allowlist precision | Exceptions are often broad file, symbol, regex, or inline suppression patterns. | Each exception must match one exact selector: `{path, owner, category}`. Broad file-level or owner-only exceptions are not supported in schema version `2`. |
+| Allowlist precision | Exceptions are often broad file, symbol, regex, or inline suppression patterns. | Each exception resolves to one exact selector identity: `{path, owner, category, line, column}`. Legacy selectors without coordinates are accepted only when `{path, owner, category}` still resolves to exactly one current finding. Broad file-level or owner-only exceptions are not supported in schema version `2`. |
 | Stale selector rejection | Suppressions can drift silently after refactors or when the original finding disappears. | Selectors that no longer resolve to a current finding are rejected as stale or typoed configuration. |
-| Canonical finding identity | Findings are often tied to textual matches or positions only. | Each finding has one canonical identity captured as `{path, owner, category}`, and diagnostics are emitted in deterministic order. |
+| Canonical finding identity | Findings are often tied to textual matches or positions only. | Each finding has one canonical identity captured as `{path, owner, category, line, column}`, and diagnostics are emitted in deterministic order. |
 | Configuration hygiene | Config validation is often looser because the tool's job is just pattern matching. | Unknown, malformed, duplicate, ambiguous, and unresolved selectors are rejected and analysis fails closed. |
 | Detection contract | Supported and unsupported cases are often implicit in the matcher. | The README defines the exact supported AST parent/child slots and explicitly documents unsupported and ambiguous cases as part of the public contract. |
 
@@ -80,16 +80,20 @@ entries:
       path: internal/validation/analyzer.go
       owner: analyzerConfig
       category: "*ast.Field.Type"
+      line: 84
+      column: 54
     description: go/analysis Run API requires returning `any`
 ```
 
-Each entry must provide an exact `selector` with the canonical `{path, owner, category}` finding identity.
+Each entry must resolve to one exact finding. The canonical finding identity is `{path, owner, category, line, column}`.
 
 - Unknown fields are rejected during YAML decoding
 - Unknown categories are rejected during validation
 - Missing or malformed selector objects are rejected during validation
+- Selectors that set only one of `line` or `column` are rejected during validation
 - Duplicate selectors are rejected as ambiguous configuration
 - Selectors that do not resolve to any collected finding are rejected as stale or typoed configuration
+- Legacy selectors that omit `line` and `column` are accepted only when their `{path, owner, category}` triple resolves to exactly one current finding. Collisions are rejected as ambiguous configuration
 - Broad file-level or owner-only allowlist entries are not supported in version `2`
 
 ### Detection Contract
@@ -139,7 +143,10 @@ Nested `any` is reportable only when the nested identifier still appears in one 
 - `*ast.FuncDecl` uses the function name, or the receiver type name for methods
 - Local declarations inside a function or method inherit that enclosing function or receiver type owner
 - Category identity is the supported AST slot label captured at collection time, for example `*ast.MapType.Value`
-- Allowlist selectors match only by the exact collected `{path, owner, category}` identity
+- Line and column identity are the exact 1-based source coordinates of the matched `any` token
+- Canonical finding identity is the exact collected `{path, owner, category, line, column}` tuple
+- Allowlist selectors with `line` and `column` match only by that exact collected identity
+- Legacy selectors without coordinates are resolved only if their `{path, owner, category}` triple matches exactly one current finding
 - Owner or category are never inferred during allowlist matching
 - A selector that does not resolve to a current finding is treated as a configuration error
 

--- a/docs/golangci-lint/README.md
+++ b/docs/golangci-lint/README.md
@@ -55,7 +55,7 @@ linters:
 
 - Analyzer/plugin path: golangci-lint loads `anyguard` as a `go/analysis` linter and runs one pass per package. Each pass reports only the findings owned by that package after applying the configured roots and `exclude_globs` to the same canonical repository-relative file identities used by repo-wide allowlist resolution.
 - Repo-wide stale-selector validation still happens in that mode. The allowlist is resolved against repo-wide findings across the configured roots once per golangci-lint process and reused by later package passes.
-- Audit path: the repo-wide validation helper used by this repository's tests and benchmarks walks the configured roots once, applies the active Go build context (`//go:build`, `GOOS`, `GOARCH`, file suffix constraints, and `CGO_ENABLED`), and returns the full violation set. That is the whole-repo audit reference point; the module plugin does not repeat that work on every package.
+- Audit path: the repo-wide validation helper used by this repository's tests and benchmarks walks the configured roots once, applies the active Go build context (`//go:build`, `GOOS`, `GOARCH`, file suffix constraints, and `CGO_ENABLED`), and returns the full violation set. That is the whole-repo audit reference point. The module plugin does not repeat that work on every package.
 
 ## Load mode and performance
 
@@ -64,7 +64,9 @@ linters:
 - The plugin also pays one repo-wide allowlist-validation cost per golangci-lint process so stale selectors remain fail-closed across the configured roots.
 - It does not run a whole-repo diagnostic audit on every package. Only current-package diagnostics are emitted per pass.
 - Compared with the audit path, the tradeoff is higher per-package `typesinfo` loading but no repeated repo scan for every package.
-- Finding identity, allowlist matching, and diagnostic ordering do not change.
+- Module-plugin diagnostics stay sorted by `file`, `line`, `column`, `category`, and `owner`, independent of configured root order, filesystem traversal order, and map iteration.
+- Canonical finding identity and exact allowlist matching include `line` and `column` coordinates.
+- Legacy allowlist selectors that omit coordinates are accepted only when `{path, owner, category}` still resolves to exactly one current finding.
 - Measure the repository smoke path with:
 
 ```bash
@@ -95,13 +97,14 @@ For maintainers evaluating possible core inclusion:
 
 - The normative spec is the root [`Behavior`](../../README.md#behavior), [`Comparison With Generic Ban-Pattern Linters`](../../README.md#comparison-with-generic-ban-pattern-linters), [`Allowlist Schema`](../../README.md#allowlist-schema), and [`Detection Contract`](../../README.md#detection-contract).
 - Supported syntax categories are exactly the AST child slots in the detection contract. Every supported slot resolves the universe `any` alias. The only slots outside dedicated type positions are the three compatibility slots. Anything outside that list is out of scope and intentionally silent.
-- Each finding has one exact identity: `{path, owner, category}`. Allowlist matching is exact on that identity only.
+- Each finding has one exact identity: `{path, owner, category, line, column}`. Allowlist matching is exact on that identity.
+- Legacy selectors without `line` and `column` are accepted only when their `{path, owner, category}` triple still resolves to exactly one current finding.
 - Module-plugin execution is package-local for diagnostics, but stale-selector validation remains repo-wide across the configured roots and is reused across package passes in the same process.
 - The analyzer fails closed on unresolved file identity, allowlist parse/validation errors, stale or ambiguous selectors, and traversal or parse failures.
 - CLI, analyzer, and module-plugin reporting order is a compatibility guarantee: no scoring, no heuristic ranking, and stable sort order by `file`, `line`, `column`, `category`, and `owner`.
 - Ordering does not depend on configured root order, filesystem traversal order, or map iteration.
 - False positives should mostly come down to scope. There are no syntax-only slots. `*ast.CallExpr.Fun`, `*ast.IndexExpr.Index`, and `*ast.IndexListExpr.Indices[i]` remain supported compatibility slots, so cases such as `any(1)`, `Single[any]{}`, and `Box[int, any]{}` remain reportable by contract.
-- Allowlist strictness is deliberate in schema version `2`: no broad file-level or owner-only exceptions, no duplicate selectors, and no selectors that fail to resolve to a current finding.
+- Allowlist strictness is deliberate in schema version `2`: no broad file-level or owner-only exceptions, no duplicate selectors, no half-specified selector coordinates, and no selectors that fail to resolve to a current finding.
 - Non-goals: type-parameter constraints, broader unsafe-dynamic-use detection, or claims that every finding is a bug or security issue.
 - The root comparison section is the canonical answer to "why not just use an existing ban-pattern linter?": overlap exists at the policy level, but `anyguard` is specifically about exact exceptions, stale-selector rejection, and a documented syntax-slot contract.
 - Treat this as a policy linter, not a detector. It enforces repository policy over `any`. Upstream inclusion is still not guaranteed.

--- a/internal/benchtest/benchtest.go
+++ b/internal/benchtest/benchtest.go
@@ -23,6 +23,7 @@ const (
 	defaultConfiguredRoot = "./..."
 	goModFileName         = "go.mod"
 	syntheticNameFormat   = "%s_%02d"
+	syntheticAnyName      = "any"
 )
 
 const (
@@ -50,6 +51,8 @@ type Selector struct {
 	Path     string
 	Owner    string
 	Category string
+	Line     int
+	Column   int
 }
 
 type RepoStats struct {
@@ -291,6 +294,8 @@ func writeAllowlist(tb testing.TB, path string, selectors []Selector) {
 		fmt.Fprintf(&builder, "      path: %q\n", selector.Path)
 		fmt.Fprintf(&builder, "      owner: %q\n", selector.Owner)
 		fmt.Fprintf(&builder, "      category: %q\n", selector.Category)
+		fmt.Fprintf(&builder, "      line: %d\n", selector.Line)
+		fmt.Fprintf(&builder, "      column: %d\n", selector.Column)
 		builder.WriteString("    description: benchmark fixture allowlist entry\n")
 	}
 
@@ -328,13 +333,67 @@ func writeUsageFile(tb testing.TB, root, pkgName, relPath string, fileIndex int)
 	builder.WriteString("\t_ = local\n")
 	builder.WriteString("}\n")
 
-	writeFile(tb, root, relPath, builder.String())
+	content := builder.String()
+	writeFile(tb, root, relPath, content)
+
+	lines := strings.Split(content, "\n")
+	payloadLine := selectorLine(tb, lines, fmt.Sprintf("type %s map[any][]any", payloadOwner))
+	aliasLine := selectorLine(tb, lines, fmt.Sprintf("type %s = %s", aliasOwner, syntheticAnyName))
+	useFieldLine := selectorLine(tb, lines, fmt.Sprintf("func %s(%s any) {", useOwner, safeParam))
+	useCallLine := selectorLine(tb, lines, fmt.Sprintf("\t_ = %s(%s)", syntheticAnyName, safeParam))
 	return []Selector{
-		{Path: relPath, Owner: payloadOwner, Category: categoryMapTypeKey},
-		{Path: relPath, Owner: aliasOwner, Category: categoryTypeSpecType},
-		{Path: relPath, Owner: useOwner, Category: categoryFieldType},
-		{Path: relPath, Owner: useOwner, Category: categoryCallExprFun},
+		{
+			Path:     relPath,
+			Owner:    payloadOwner,
+			Category: categoryMapTypeKey,
+			Line:     payloadLine,
+			Column:   selectorColumn(tb, lines[payloadLine-1], "[any]", 1),
+		},
+		{
+			Path:     relPath,
+			Owner:    aliasOwner,
+			Category: categoryTypeSpecType,
+			Line:     aliasLine,
+			Column:   selectorColumn(tb, lines[aliasLine-1], syntheticAnyName, 0),
+		},
+		{
+			Path:     relPath,
+			Owner:    useOwner,
+			Category: categoryFieldType,
+			Line:     useFieldLine,
+			Column:   selectorColumn(tb, lines[useFieldLine-1], syntheticAnyName, 0),
+		},
+		{
+			Path:     relPath,
+			Owner:    useOwner,
+			Category: categoryCallExprFun,
+			Line:     useCallLine,
+			Column:   selectorColumn(tb, lines[useCallLine-1], "any(", 0),
+		},
 	}
+}
+
+func selectorLine(tb testing.TB, lines []string, needle string) int {
+	tb.Helper()
+
+	for i, line := range lines {
+		if line == needle {
+			return i + 1
+		}
+	}
+
+	tb.Fatalf("selector line: %q missing from generated content", needle)
+	return 0
+}
+
+func selectorColumn(tb testing.TB, line, needle string, offset int) int {
+	tb.Helper()
+
+	index := strings.Index(line, needle)
+	if index < 0 {
+		tb.Fatalf("selector column: %q missing from %q", needle, line)
+	}
+	return index + offset + 1
 }
 
 func writeSafeFile(tb testing.TB, root, pkgName, relPath string, fileIndex int) {

--- a/internal/ci/any_allowlist.yaml
+++ b/internal/ci/any_allowlist.yaml
@@ -6,4 +6,6 @@ entries:
       path: internal/validation/analyzer.go
       owner: analyzerConfig
       category: "*ast.Field.Type"
+      line: 84
+      column: 54
     description: go/analysis Run API requires returning `any`

--- a/internal/validation/analyzer_test.go
+++ b/internal/validation/analyzer_test.go
@@ -433,10 +433,10 @@ func TestCollectAnalyzerViolationsSortsAcrossFileOrder(t *testing.T) {
 		{relPath: testAlphaPayloadPath, tokenFile: alphaFile},
 	}
 	findings := []collectedFinding{
-		{identity: newFindingIdentity(testZetaLaterPath, testOwnerLater, anyCategoryCallExprFun), line: 2, column: 31},
-		{identity: newFindingIdentity(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeValue), line: 2, column: 22},
-		{identity: newFindingIdentity(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeKey), line: 2, column: 18},
-		{identity: newFindingIdentity(testZetaLaterPath, testOwnerLater, anyCategoryCallExprFun), line: 2, column: 23},
+		{identity: newFindingIdentity(testZetaLaterPath, testOwnerLater, anyCategoryCallExprFun, 2, 31), line: 2, column: 31},
+		{identity: newFindingIdentity(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeValue, 2, 22), line: 2, column: 22},
+		{identity: newFindingIdentity(testAlphaPayloadPath, testOwnerPayload, anyCategoryMapTypeKey, 2, 18), line: 2, column: 18},
+		{identity: newFindingIdentity(testZetaLaterPath, testOwnerLater, anyCategoryCallExprFun, 2, 23), line: 2, column: 23},
 	}
 
 	reportable := collectAnalyzerViolations(files, findings, anyAllowlistIndex{})
@@ -483,6 +483,8 @@ func TestReportViolationUsesLineAndColumn(t *testing.T) {
 			File:     "pkg/report.go",
 			Owner:    "Use",
 			Category: string(anyCategoryCallExprFun),
+			Line:     2,
+			Column:   18,
 		},
 	})
 

--- a/internal/validation/any_usage.go
+++ b/internal/validation/any_usage.go
@@ -26,15 +26,17 @@ import (
 const anyguardLinter = "anyguard"
 
 const (
-	anyAllowlistVersion = 2
-	rootWildcardSuffix  = "/..."
-	rootAllPattern      = "..."
-	anyTokenMarker      = "<<ANY>>"
-	anyName             = "any"
-	sourceImporterMode  = "source"
-	goosEnvVar          = "GOOS"
-	goarchEnvVar        = "GOARCH"
-	cgoEnabledEnvVar    = "CGO_ENABLED"
+	anyAllowlistVersion   = 2
+	rootWildcardSuffix    = "/..."
+	rootAllPattern        = "..."
+	anyTokenMarker        = "<<ANY>>"
+	anyName               = "any"
+	sourceImporterMode    = "source"
+	goosEnvVar            = "GOOS"
+	goarchEnvVar          = "GOARCH"
+	cgoEnabledEnvVar      = "CGO_ENABLED"
+	errDuplicateSelector  = "any allowlist entries %d and %d resolve to the same selector %s"
+	errUnresolvedSelector = "any allowlist entry %d selector %s does not match any finding"
 )
 
 var nolintDirectiveRE = regexp.MustCompile(`(?i)\bnolint(?::([a-z0-9_,-]+))?`)
@@ -71,6 +73,8 @@ type FindingIdentity struct {
 	File     string
 	Owner    string
 	Category string
+	Line     int
+	Column   int
 }
 
 // AnyAllowlist captures approved any-usage locations for enforcement.
@@ -81,11 +85,14 @@ type AnyAllowlist struct {
 }
 
 // AnyAllowlistSelector describes the canonical finding identity a strict allowlist
-// entry must resolve to.
+// entry must resolve to. Line and column may be omitted only for legacy
+// selectors that still resolve uniquely.
 type AnyAllowlistSelector struct {
 	Path     string `yaml:"path"`
 	Owner    string `yaml:"owner"`
 	Category string `yaml:"category"`
+	Line     int    `yaml:"line"`
+	Column   int    `yaml:"column"`
 }
 
 // AnyAllowlistEntry describes a scoped any-usage exception.
@@ -505,7 +512,7 @@ func validateAllowlistEntry(entry AnyAllowlistEntry, index int, seenSelectors ma
 	identity := selector.identity()
 	if prev, exists := seenSelectors[identity]; exists {
 		return AnyAllowlistEntry{}, fmt.Errorf(
-			"any allowlist entries %d and %d resolve to the same selector %s",
+			errDuplicateSelector,
 			prev,
 			index,
 			formatFindingIdentity(identity),
@@ -539,6 +546,15 @@ func normalizeValidatedSelector(selector *AnyAllowlistSelector, index int) (AnyA
 			normalized.Category,
 		)
 	}
+	if normalized.Line == 0 && normalized.Column == 0 {
+		return normalized, nil
+	}
+	if normalized.Line <= 0 || normalized.Column <= 0 {
+		return AnyAllowlistSelector{}, fmt.Errorf(
+			"any allowlist entry %d selector line and column must both be positive when either is set",
+			index,
+		)
+	}
 	return normalized, nil
 }
 
@@ -563,13 +579,13 @@ type anyAllowlistIndex struct {
 	allowed map[FindingIdentity]struct{}
 }
 
-func buildAllowlistIndex(allowlist AnyAllowlist) anyAllowlistIndex {
+func buildAllowlistIndex(identities []FindingIdentity) anyAllowlistIndex {
 	index := anyAllowlistIndex{
-		allowed: make(map[FindingIdentity]struct{}, len(allowlist.Entries)),
+		allowed: make(map[FindingIdentity]struct{}, len(identities)),
 	}
 
-	for _, entry := range allowlist.Entries {
-		index.allowed[entry.Selector.identity()] = struct{}{}
+	for _, identity := range identities {
+		index.allowed[identity] = struct{}{}
 	}
 
 	return index
@@ -599,8 +615,9 @@ func collectParsedFileFindings(fset *token.FileSet, info *types.Info, file parse
 	findings := make([]collectedFinding, 0, len(uses))
 	for _, usage := range uses {
 		pos := fset.Position(usage.pos)
+		identity := usage.identity.withPosition(pos.Line, pos.Column)
 		findings = append(findings, collectedFinding{
-			identity:           usage.identity,
+			identity:           identity,
 			line:               pos.Line,
 			column:             pos.Column,
 			code:               lineCode(pos.Line, lines),
@@ -688,23 +705,72 @@ func sortViolations(violations []Error) {
 
 func resolveAllowlistIndex(allowlist AnyAllowlist, findings []collectedFinding) (anyAllowlistIndex, error) {
 	available := make(map[FindingIdentity]struct{}, len(findings))
+	legacyMatches := make(map[FindingIdentity][]FindingIdentity, len(findings))
 	for _, finding := range findings {
 		available[finding.identity] = struct{}{}
+		legacyKey := finding.identity.withoutPosition()
+		legacyMatches[legacyKey] = append(legacyMatches[legacyKey], finding.identity)
 	}
 
+	resolved := make([]FindingIdentity, 0, len(allowlist.Entries))
+	resolvedEntries := make(map[FindingIdentity]int, len(allowlist.Entries))
 	for i, entry := range allowlist.Entries {
-		identity := entry.Selector.identity()
-		if _, ok := available[identity]; ok {
-			continue
+		identity, err := resolveAllowlistSelector(i, *entry.Selector, available, legacyMatches)
+		if err != nil {
+			return anyAllowlistIndex{}, err
 		}
-		return anyAllowlistIndex{}, fmt.Errorf(
-			"any allowlist entry %d selector %s does not match any finding",
-			i,
+		if prev, exists := resolvedEntries[identity]; exists {
+			return anyAllowlistIndex{}, fmt.Errorf(
+				errDuplicateSelector,
+				prev,
+				i,
+				formatFindingIdentity(identity),
+			)
+		}
+		resolvedEntries[identity] = i
+		resolved = append(resolved, identity)
+	}
+
+	return buildAllowlistIndex(resolved), nil
+}
+
+func resolveAllowlistSelector(
+	index int,
+	selector AnyAllowlistSelector,
+	available map[FindingIdentity]struct{},
+	legacyMatches map[FindingIdentity][]FindingIdentity,
+) (FindingIdentity, error) {
+	identity := selector.identity()
+	if selector.hasPosition() {
+		if _, ok := available[identity]; ok {
+			return identity, nil
+		}
+		return FindingIdentity{}, fmt.Errorf(
+			errUnresolvedSelector,
+			index,
 			formatFindingIdentity(identity),
 		)
 	}
 
-	return buildAllowlistIndex(allowlist), nil
+	matches := legacyMatches[identity]
+	switch len(matches) {
+	case 0:
+		return FindingIdentity{}, fmt.Errorf(
+			errUnresolvedSelector,
+			index,
+			formatFindingIdentity(identity),
+		)
+	case 1:
+		return matches[0], nil
+	default:
+		return FindingIdentity{}, fmt.Errorf(
+			"any allowlist entry %d selector %s is ambiguous and matches %d findings: %s; add line and column",
+			index,
+			formatFindingIdentity(identity),
+			len(matches),
+			formatFindingIdentities(matches),
+		)
+	}
 }
 
 func (selector AnyAllowlistSelector) identity() FindingIdentity {
@@ -712,11 +778,31 @@ func (selector AnyAllowlistSelector) identity() FindingIdentity {
 		File:     selector.Path,
 		Owner:    selector.Owner,
 		Category: selector.Category,
+		Line:     selector.Line,
+		Column:   selector.Column,
 	}
 }
 
 func formatFindingIdentity(identity FindingIdentity) string {
+	if identity.hasPosition() {
+		return fmt.Sprintf(
+			"{path=%q owner=%q category=%q line=%d column=%d}",
+			identity.File,
+			identity.Owner,
+			identity.Category,
+			identity.Line,
+			identity.Column,
+		)
+	}
 	return fmt.Sprintf("{path=%q owner=%q category=%q}", identity.File, identity.Owner, identity.Category)
+}
+
+func formatFindingIdentities(identities []FindingIdentity) string {
+	parts := make([]string, 0, len(identities))
+	for _, identity := range identities {
+		parts = append(parts, formatFindingIdentity(identity))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func collectNolintLines(file *ast.File, fset *token.FileSet) map[int]struct{} {
@@ -941,18 +1027,40 @@ func (collector *anyUsageCollector) visitCompositeTypeAnySlot(category anyUsageC
 func (collector *anyUsageCollector) recordPredeclaredAnyUsage(category anyUsageCategory, owner string, expr ast.Expr) {
 	if ident, ok := predeclaredAnyIdent(expr, collector.info); ok {
 		collector.usages = append(collector.usages, anyUsage{
-			identity: newFindingIdentity(collector.file, owner, category),
+			identity: newFindingIdentity(collector.file, owner, category, 0, 0),
 			pos:      ident.Pos(),
 		})
 	}
 }
 
-func newFindingIdentity(relPath, owner string, category anyUsageCategory) FindingIdentity {
+func newFindingIdentity(relPath, owner string, category anyUsageCategory, line, column int) FindingIdentity {
 	return FindingIdentity{
 		File:     relPath,
 		Owner:    owner,
 		Category: string(category),
+		Line:     line,
+		Column:   column,
 	}
+}
+
+func (selector AnyAllowlistSelector) hasPosition() bool {
+	return selector.Line > 0 && selector.Column > 0
+}
+
+func (identity FindingIdentity) hasPosition() bool {
+	return identity.Line > 0 && identity.Column > 0
+}
+
+func (identity FindingIdentity) withPosition(line, column int) FindingIdentity {
+	identity.Line = line
+	identity.Column = column
+	return identity
+}
+
+func (identity FindingIdentity) withoutPosition() FindingIdentity {
+	identity.Line = 0
+	identity.Column = 0
+	return identity
 }
 
 func (collector *anyUsageCollector) inspectNode(node ast.Node, owner string) {

--- a/internal/validation/any_usage_test.go
+++ b/internal/validation/any_usage_test.go
@@ -40,6 +40,7 @@ const (
 	testOwnerAlpha             = "Alpha"
 	testOwnerBeta              = "Beta"
 	testOwnerZulu              = "Zulu"
+	testOwnerReceiver          = "Receiver"
 	testSamplePath             = "sample.go"
 	testPackageAPISource       = "package api\n"
 	testPayloadTestFile        = "payload_test.go"
@@ -52,6 +53,11 @@ const (
 	testAlphaPayloadSource     = "package alpha\ntype Payload map[any]any\n"
 	testZetaLaterPath          = "pkg/zeta/later.go"
 	testZetaLaterSource        = "package zeta\nfunc Later() { _, _ = any(1), any(2) }\n"
+	testMethodsFile            = "methods.go"
+	testMethodsPath            = "pkg/api/methods.go"
+	testReceiverMethodsSource  = "package api\n\ntype Receiver struct{}\n\nfunc (Receiver) First(v any) {}\nfunc (Receiver) Second(v any) {}\n"
+	testPayloadLine            = 2
+	testPayloadColumn          = 25
 	testExpectedNormalizeRoots = "."
 	testUnexpectedDeclUsages   = "unexpected declaration-slot usages:\ngot: %#v\nwant: %#v"
 	testUnexpectedCompUsages   = "unexpected composite-slot usages:\ngot: %#v\nwant: %#v"
@@ -114,7 +120,14 @@ func TestValidateAnyUsageFromFile(t *testing.T) {
 		Version:      anyAllowlistVersion,
 		ExcludeGlobs: []string{"**/*_test.go"},
 		Entries: []AnyAllowlistEntry{
-			allowlistEntry(testPayloadPath, testOwnerPayload, anyCategoryMapTypeValue, testPayloadBoundaryDesc),
+			allowlistEntry(
+				testPayloadPath,
+				testOwnerPayload,
+				anyCategoryMapTypeValue,
+				testPayloadLine,
+				testPayloadColumn,
+				testPayloadBoundaryDesc,
+			),
 		},
 	}
 	allowPath := filepath.Join(base, testAllowlistFile)
@@ -149,8 +162,34 @@ func TestValidateAnyUsageDetectsViolation(t *testing.T) {
 	if violations[0].Column != 25 {
 		t.Fatalf("unexpected column: %d", violations[0].Column)
 	}
-	if got, want := violations[0].Identity, newFindingIdentity(testPayloadPath, testOwnerPayload, anyCategoryMapTypeValue); got != want {
+	if got, want := violations[0].Identity, newFindingIdentity(
+		testPayloadPath,
+		testOwnerPayload,
+		anyCategoryMapTypeValue,
+		testPayloadLine,
+		testPayloadColumn,
+	); got != want {
 		t.Fatalf("unexpected identity: got %#v want %#v", got, want)
+	}
+}
+
+func TestValidateAnyUsageSupportsUniqueLegacySelector(t *testing.T) {
+	base := t.TempDir()
+	writeFile(t, apiPath(base, testPayloadFile), testPayloadSource)
+
+	allowlist := AnyAllowlist{
+		Version: anyAllowlistVersion,
+		Entries: []AnyAllowlistEntry{
+			legacyAllowlistEntry(testPayloadPath, testOwnerPayload, anyCategoryMapTypeValue, testPayloadBoundaryDesc),
+		},
+	}
+
+	violations, err := ValidateAnyUsage(allowlist, base, []string{testRootAPI})
+	if err != nil {
+		t.Fatalf(testValidateUsageErrFmt, err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf(testNoViolationsErrFmt, violations)
 	}
 }
 
@@ -667,7 +706,14 @@ func TestValidateAnyUsageRejectsDuplicateSelectors(t *testing.T) {
 	base := t.TempDir()
 	writeFile(t, apiPath(base, testPayloadFile), testPayloadSource)
 
-	selector := allowlistEntry(testPayloadPath, testOwnerPayload, anyCategoryMapTypeValue, testPayloadBoundaryDesc)
+	selector := allowlistEntry(
+		testPayloadPath,
+		testOwnerPayload,
+		anyCategoryMapTypeValue,
+		testPayloadLine,
+		testPayloadColumn,
+		testPayloadBoundaryDesc,
+	)
 	allowlist := AnyAllowlist{
 		Version: anyAllowlistVersion,
 		Entries: []AnyAllowlistEntry{
@@ -692,7 +738,7 @@ func TestValidateAnyUsageRejectsUnresolvedSelector(t *testing.T) {
 	allowlist := AnyAllowlist{
 		Version: anyAllowlistVersion,
 		Entries: []AnyAllowlistEntry{
-			allowlistEntry(testPayloadPath, "Paylod", anyCategoryMapTypeValue, "typoed owner"),
+			legacyAllowlistEntry(testPayloadPath, "Paylod", anyCategoryMapTypeValue, "typoed owner"),
 		},
 	}
 
@@ -727,6 +773,96 @@ func TestValidateAnyUsageRejectsMalformedSelector(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "selector missing owner") {
 		t.Fatalf(testUnexpectedErrFmt, err)
+	}
+}
+
+func TestValidateAnyUsageRejectsHalfSpecifiedSelectorPosition(t *testing.T) {
+	base := t.TempDir()
+	writeFile(t, apiPath(base, testPayloadFile), testPayloadSource)
+
+	allowlist := AnyAllowlist{
+		Version: anyAllowlistVersion,
+		Entries: []AnyAllowlistEntry{
+			{
+				Selector: &AnyAllowlistSelector{
+					Path:     testPayloadPath,
+					Owner:    testOwnerPayload,
+					Category: string(anyCategoryMapTypeValue),
+					Line:     testPayloadLine,
+				},
+				Description: "missing selector column",
+			},
+		},
+	}
+
+	_, err := ValidateAnyUsage(allowlist, base, []string{testRootAPI})
+	if err == nil {
+		t.Fatalf("expected selector coordinate validation error")
+	}
+	if !strings.Contains(err.Error(), "line and column must both be positive") {
+		t.Fatalf(testUnexpectedErrFmt, err)
+	}
+}
+
+func TestValidateAnyUsageRejectsAmbiguousLegacySelector(t *testing.T) {
+	base := t.TempDir()
+	writeFile(
+		t,
+		apiPath(base, testMethodsFile),
+		testReceiverMethodsSource,
+	)
+
+	allowlist := AnyAllowlist{
+		Version: anyAllowlistVersion,
+		Entries: []AnyAllowlistEntry{
+			legacyAllowlistEntry(testMethodsPath, testOwnerReceiver, anyCategoryFieldType, "legacy selector should be ambiguous"),
+		},
+	}
+
+	_, err := ValidateAnyUsage(allowlist, base, []string{testRootAPI})
+	if err == nil {
+		t.Fatalf("expected ambiguous selector error")
+	}
+	if !strings.Contains(err.Error(), "is ambiguous and matches 2 findings") {
+		t.Fatalf(testUnexpectedErrFmt, err)
+	}
+	if !strings.Contains(err.Error(), "add line and column") {
+		t.Fatalf(testUnexpectedErrFmt, err)
+	}
+}
+
+func TestValidateAnyUsageAllowsExactSelectorForCollidingFindings(t *testing.T) {
+	base := t.TempDir()
+	writeFile(
+		t,
+		apiPath(base, testMethodsFile),
+		testReceiverMethodsSource,
+	)
+
+	violations, err := ValidateAnyUsage(AnyAllowlist{Version: anyAllowlistVersion}, base, []string{testRootAPI})
+	if err != nil {
+		t.Fatalf(testValidateUsageErrFmt, err)
+	}
+	if len(violations) != 2 {
+		t.Fatalf("expected two colliding findings, got %d", len(violations))
+	}
+
+	allowlist := AnyAllowlist{
+		Version: anyAllowlistVersion,
+		Entries: []AnyAllowlistEntry{
+			allowlistEntryFromIdentity(violations[0].Identity, "allow only the first receiver method parameter"),
+		},
+	}
+
+	got, err := ValidateAnyUsage(allowlist, base, []string{testRootAPI})
+	if err != nil {
+		t.Fatalf(testValidateUsageErrFmt, err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected one remaining violation, got %d", len(got))
+	}
+	if got[0].Identity != violations[1].Identity {
+		t.Fatalf("unexpected remaining violation: got %#v want %#v", got[0].Identity, violations[1].Identity)
 	}
 }
 
@@ -1363,21 +1499,20 @@ func TestSortCollectedFindingsOrdersByFileLineColumnCategoryOwnerCodeAndSuppress
 }
 
 func TestAnyAllowlistIndexMatchesStrictSelectorIdentity(t *testing.T) {
-	index := buildAllowlistIndex(AnyAllowlist{
-		Version: anyAllowlistVersion,
-		Entries: []AnyAllowlistEntry{
-			allowlistEntry(testPayloadPath, testOwnerUse, anyCategoryCallExprFun, "exact selector allow"),
-		},
-	})
+	identity := newFindingIdentity(testPayloadPath, testOwnerUse, anyCategoryCallExprFun, 4, 8)
+	index := buildAllowlistIndex([]FindingIdentity{identity})
 
-	if !index.isAllowed(newFindingIdentity(testPayloadPath, testOwnerUse, anyCategoryCallExprFun)) {
+	if !index.isAllowed(identity) {
 		t.Fatalf("expected exact selector match")
 	}
-	if index.isAllowed(newFindingIdentity(testPayloadPath, testOwnerUse, anyCategoryFieldType)) {
+	if index.isAllowed(newFindingIdentity(testPayloadPath, testOwnerUse, anyCategoryFieldType, 4, 8)) {
 		t.Fatalf("did not expect selector to match a different category")
 	}
-	if index.isAllowed(newFindingIdentity(testPayloadPath, testOwnerPayload, anyCategoryCallExprFun)) {
+	if index.isAllowed(newFindingIdentity(testPayloadPath, testOwnerPayload, anyCategoryCallExprFun, 4, 8)) {
 		t.Fatalf("did not expect selector to match a different owner")
+	}
+	if index.isAllowed(newFindingIdentity(testPayloadPath, testOwnerUse, anyCategoryCallExprFun, 4, 9)) {
+		t.Fatalf("did not expect selector to match a different position")
 	}
 }
 
@@ -1388,9 +1523,9 @@ func TestValidateAnyUsageUsesEnclosingFunctionOwnerForLocalDeclarations(t *testi
 	allowlist := AnyAllowlist{
 		Version: anyAllowlistVersion,
 		Entries: []AnyAllowlistEntry{
-			allowlistEntry(testPayloadPath, testOwnerUse, anyCategoryTypeSpecType, "allow local type alias"),
-			allowlistEntry(testPayloadPath, testOwnerUse, anyCategoryMapTypeValue, "allow local map usage"),
-			allowlistEntry(testPayloadPath, testOwnerUse, anyCategoryFieldType, "allow nested function parameter"),
+			allowlistEntry(testPayloadPath, testOwnerUse, anyCategoryTypeSpecType, 3, 16, "allow local type alias"),
+			allowlistEntry(testPayloadPath, testOwnerUse, anyCategoryMapTypeValue, 4, 23, "allow local map usage"),
+			allowlistEntry(testPayloadPath, testOwnerUse, anyCategoryFieldType, 5, 13, "allow nested function parameter"),
 		},
 	}
 
@@ -1781,7 +1916,7 @@ func testCollectedFinding(
 	suppressed bool,
 ) collectedFinding {
 	return collectedFinding{
-		identity:           newFindingIdentity(path, owner, category),
+		identity:           newFindingIdentity(path, owner, category, line, column),
 		line:               line,
 		column:             column,
 		code:               code,
@@ -1801,12 +1936,43 @@ func writeAllowlist(t *testing.T, path string, allowlist AnyAllowlist) {
 	}
 }
 
-func allowlistEntry(path, owner string, category anyUsageCategory, description string) AnyAllowlistEntry {
+func allowlistEntry(
+	path, owner string,
+	category anyUsageCategory,
+	line, column int,
+	description string,
+) AnyAllowlistEntry {
 	return AnyAllowlistEntry{
 		Selector: &AnyAllowlistSelector{
 			Path:     path,
 			Owner:    owner,
 			Category: string(category),
+			Line:     line,
+			Column:   column,
+		},
+		Description: description,
+	}
+}
+
+func legacyAllowlistEntry(path, owner string, category anyUsageCategory, description string) AnyAllowlistEntry {
+	return AnyAllowlistEntry{
+		Selector: &AnyAllowlistSelector{
+			Path:     path,
+			Owner:    owner,
+			Category: string(category),
+		},
+		Description: description,
+	}
+}
+
+func allowlistEntryFromIdentity(identity FindingIdentity, description string) AnyAllowlistEntry {
+	return AnyAllowlistEntry{
+		Selector: &AnyAllowlistSelector{
+			Path:     identity.File,
+			Owner:    identity.Owner,
+			Category: identity.Category,
+			Line:     identity.Line,
+			Column:   identity.Column,
 		},
 		Description: description,
 	}

--- a/internal/validation/benchmark_test.go
+++ b/internal/validation/benchmark_test.go
@@ -137,6 +137,8 @@ func benchmarkAllowlist(selectors []benchtest.Selector) AnyAllowlist {
 				Path:     selector.Path,
 				Owner:    selector.Owner,
 				Category: selector.Category,
+				Line:     selector.Line,
+				Column:   selector.Column,
 			},
 			Description: "benchmark fixture allowlist entry",
 		})

--- a/internal/validation/repo_validation_cache_test.go
+++ b/internal/validation/repo_validation_cache_test.go
@@ -69,7 +69,7 @@ func TestRepoValidationCacheReusesNormalizedKey(t *testing.T) {
 	want := repoValidationResult{
 		index: anyAllowlistIndex{
 			allowed: map[FindingIdentity]struct{}{
-				newFindingIdentity(testPayloadPath, testOwnerPayload, anyCategoryMapTypeValue): {},
+				newFindingIdentity(testPayloadPath, testOwnerPayload, anyCategoryMapTypeValue, testPayloadLine, testPayloadColumn): {},
 			},
 		},
 	}
@@ -112,7 +112,7 @@ func TestRepoValidationCacheConcurrentAccessCollapsesMisses(t *testing.T) {
 	want := repoValidationResult{
 		index: anyAllowlistIndex{
 			allowed: map[FindingIdentity]struct{}{
-				newFindingIdentity(testPayloadPath, testOwnerPayload, anyCategoryMapTypeValue): {},
+				newFindingIdentity(testPayloadPath, testOwnerPayload, anyCategoryMapTypeValue, testPayloadLine, testPayloadColumn): {},
 			},
 		},
 	}

--- a/internal/validation/testdata/allowlist.yaml
+++ b/internal/validation/testdata/allowlist.yaml
@@ -6,4 +6,6 @@ entries:
       path: allowed/allowed.go
       owner: Payload
       category: "*ast.MapType.Value"
+      line: 3
+      column: 25
     description: approved payload boundary

--- a/internal/validation/testdata/corpus/supported/allowlist-all.yaml
+++ b/internal/validation/testdata/corpus/supported/allowlist-all.yaml
@@ -4,64 +4,90 @@ entries:
       path: pkg/api/supported.go
       owner: FieldTypeDisallowed
       category: "*ast.Field.Type"
+      line: 3
+      column: 28
     description: allow parameter field type
   - selector:
       path: pkg/api/supported.go
       owner: ValueSpecDisallowed
       category: "*ast.ValueSpec.Type"
+      line: 5
+      column: 25
     description: allow value spec type
   - selector:
       path: pkg/api/supported.go
       owner: TypeSpecDisallowed
       category: "*ast.TypeSpec.Type"
+      line: 7
+      column: 27
     description: allow type alias
   - selector:
       path: pkg/api/supported.go
       owner: ArrayTypeDisallowed
       category: "*ast.ArrayType.Elt"
+      line: 9
+      column: 28
     description: allow array element type
   - selector:
       path: pkg/api/supported.go
       owner: MapKeyDisallowed
       category: "*ast.MapType.Key"
+      line: 11
+      column: 27
     description: allow map key type
   - selector:
       path: pkg/api/supported.go
       owner: MapValueDisallowed
       category: "*ast.MapType.Value"
+      line: 13
+      column: 36
     description: allow map value type
   - selector:
       path: pkg/api/supported.go
       owner: ChanTypeDisallowed
       category: "*ast.ChanType.Value"
+      line: 15
+      column: 33
     description: allow channel element type
   - selector:
       path: pkg/api/supported.go
       owner: StarTypeDisallowed
       category: "*ast.StarExpr.X"
+      line: 17
+      column: 26
     description: allow pointer target type
   - selector:
       path: pkg/api/supported.go
       owner: EllipsisDisallowed
       category: "*ast.Ellipsis.Elt"
+      line: 19
+      column: 35
     description: allow variadic element type
   - selector:
       path: pkg/api/supported.go
       owner: TypeAssertDisallowed
       category: "*ast.TypeAssertExpr.Type"
+      line: 22
+      column: 13
     description: allow type assertion target
   - selector:
       path: pkg/api/supported.go
       owner: CallExprDisallowed
       category: "*ast.CallExpr.Fun"
+      line: 26
+      column: 6
     description: allow compatibility any conversion
   - selector:
       path: pkg/api/supported.go
       owner: IndexExprDisallowed
       category: "*ast.IndexExpr.Index"
+      line: 34
+      column: 13
     description: allow compatibility any single-argument instantiation
   - selector:
       path: pkg/api/supported.go
       owner: IndexListDisallowed
       category: "*ast.IndexListExpr.Indices"
+      line: 38
+      column: 15
     description: allow compatibility any multi-argument instantiation

--- a/testdata/golangci/smoke/any_allowlist.yaml
+++ b/testdata/golangci/smoke/any_allowlist.yaml
@@ -4,4 +4,6 @@ entries:
       path: pkg/ok/ok.go
       owner: Payload
       category: "*ast.MapType.Value"
+      line: 3
+      column: 25
     description: allowed boundary type for smoke tests


### PR DESCRIPTION
## Summary

Tighten allowlist selector precision so one entry cannot silently suppress multiple findings that share the same `{path, owner, category}` triple.

Resolves: #57 

## What Changed

- extend canonical finding identity to include `line` and `column`
- resolve exact allowlist selectors against `{path, owner, category, line, column}`
- keep legacy three-field selectors only as a backward-compatible path when they still resolve uniquely
- reject ambiguous legacy selectors fail closed
- update repo fixtures, benchmark allowlist generation, and docs to prefer exact selectors
- add regression coverage for ambiguous receiver-method collisions and exact single-finding approval

## Why

The previous identity model allowed multiple distinct findings in the same file to collapse onto one selector. That broke the precision guarantee of the tool and made stale-selector validation weaker than documented.

## Testing

- `go test ./...`
- `go test ./internal/validation -run 'TestValidateAnyUsageAuditsWholeRepo|TestAnalyzerRunUsesRepoWideAllowlistValidation|TestAnalyzerRunReportsPackageLocalDiagnosticsAndReusesRepoValidation'`
- `golangci-lint run`
- `bash scripts/ci/run-golangci-plugin-smoke.sh`
