### PR TITLE
docs(release): Release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, with the current development state trac
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-03-22
+
 ### Fixed
 
 - Tightened canonical finding identity with exact `line` and `column` coordinates so one allowlist entry can no longer silently suppress multiple same-file, same-owner, same-category findings. Legacy three-field selectors now resolve only when unique and otherwise fail closed as ambiguous. (@TobyTheHutt)
@@ -75,7 +77,8 @@ The format is based on Keep a Changelog, with the current development state trac
 
 - Initial anyguard release with YAML allowlist support, repository scanning, and CI bootstrap for enforcing controlled `any` usage. (@TobyTheHutt)
 
-[Unreleased]: https://github.com/tobythehutt/anyguard/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/tobythehutt/anyguard/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/tobythehutt/anyguard/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/tobythehutt/anyguard/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/tobythehutt/anyguard/compare/v0.3.0...v1.0.0
 [0.3.0]: https://github.com/tobythehutt/anyguard/compare/v0.2.0...v0.3.0

--- a/docs/golangci-lint/.custom-gcl.yml
+++ b/docs/golangci-lint/.custom-gcl.yml
@@ -4,4 +4,4 @@ name: custom-gcl
 plugins:
   - module: github.com/tobythehutt/anyguard
     import: github.com/tobythehutt/anyguard/plugin
-    version: v2.0.0
+    version: v2.0.1

--- a/docs/golangci-lint/README.md
+++ b/docs/golangci-lint/README.md
@@ -117,6 +117,6 @@ For maintainers evaluating possible core inclusion:
 
 ## Release and version pinning
 
-- Keep `plugins[].version` pinned to the tag being released, for example `v2.0.0`.
+- Keep `plugins[].version` pinned to the tag being released, for example `v2.0.1`.
 - Module plugin support starts with `v1.0.0`. Do not pin below this version.
 - The plugin entrypoint import path `github.com/tobythehutt/anyguard/plugin` is stable and versioned with module tags.

--- a/testdata/golangci/.custom-gcl.yml
+++ b/testdata/golangci/.custom-gcl.yml
@@ -3,4 +3,4 @@ name: custom-gcl
 plugins:
   - module: github.com/tobythehutt/anyguard
     import: github.com/tobythehutt/anyguard/plugin
-    version: v2.0.0
+    version: v2.0.1


### PR DESCRIPTION
## Summary
- cut the `2.0.1` changelog entry from `Unreleased`
- update golangci-lint module-plugin version pins to `v2.0.1`
- align release docs and sample custom-gcl config with the new tag

Resolves: #61 
