### PR TITLE
fix: publish anyguard as a proper v2 module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog, with the current development state trac
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-03-22
+
+### Fixed
+
+- Declared the Go module as `github.com/tobythehutt/anyguard/v2` and updated analyzer, plugin, and golangci-lint module-plugin documentation to use the versioned `v2` import paths required by Go module tooling. (@TobyTheHutt)
+
 ## [2.0.1] - 2026-03-22
 
 ### Fixed
@@ -77,7 +83,8 @@ The format is based on Keep a Changelog, with the current development state trac
 
 - Initial anyguard release with YAML allowlist support, repository scanning, and CI bootstrap for enforcing controlled `any` usage. (@TobyTheHutt)
 
-[Unreleased]: https://github.com/tobythehutt/anyguard/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/tobythehutt/anyguard/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/tobythehutt/anyguard/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/tobythehutt/anyguard/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/tobythehutt/anyguard/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/tobythehutt/anyguard/compare/v0.3.0...v1.0.0

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Release history lives in [`CHANGELOG.md`](CHANGELOG.md).
 ### Get Started
 
 ```bash
+go install github.com/tobythehutt/anyguard/v2/cmd/anyguard@latest
 anyguard -allowlist internal/ci/any_allowlist.yaml ./...
 ```
 
@@ -200,7 +201,7 @@ The benchmark suite includes `ValidateAnyUsage`, repo-wide finding collection an
 
 `anyguard` can run as a golangci-lint module plugin.
 
-- Stable plugin import path: `github.com/tobythehutt/anyguard/plugin`
+- Stable plugin import path: `github.com/tobythehutt/anyguard/v2/plugin`
 - Plugin name in `.golangci.yml`: `anyguard`
 - Plugin diagnostics follow the same deterministic ordering contract as the CLI and public analyzer.
 - The module plugin requests golangci-lint `typesinfo` load mode so supported-slot matching can use `analysis.Pass.TypesInfo`.
@@ -212,10 +213,18 @@ The benchmark suite includes `ValidateAnyUsage`, repo-wide finding collection an
 
 For direct integration into `golangci-lint`, import the public analyzer entrypoint.
 
-- Module path: `github.com/tobythehutt/anyguard`
+- Module path: `github.com/tobythehutt/anyguard/v2`
 - Analyzer constructor: `anyguard.NewAnalyzer()`
 - The analyzer uses `analysis.Pass.TypesInfo` and runs despite errors so partial type info is still available on ill-typed packages.
 - Analyzer diagnostics follow the same deterministic ordering contract as the CLI and module plugin.
+
+```go
+import anyguard "github.com/tobythehutt/anyguard/v2"
+```
+
+```bash
+go get github.com/tobythehutt/anyguard/v2@v2.0.2
+```
 
 ### License
 

--- a/anyguard.go
+++ b/anyguard.go
@@ -2,7 +2,7 @@
 package anyguard
 
 import (
-	"github.com/tobythehutt/anyguard/internal/validation"
+	"github.com/tobythehutt/anyguard/v2/internal/validation"
 	"golang.org/x/tools/go/analysis"
 )
 

--- a/cmd/anyguard/main.go
+++ b/cmd/anyguard/main.go
@@ -2,7 +2,7 @@
 package main
 
 import (
-	"github.com/tobythehutt/anyguard/internal/validation"
+	"github.com/tobythehutt/anyguard/v2/internal/validation"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/singlechecker"
 )

--- a/cmd/anyguard/main_test.go
+++ b/cmd/anyguard/main_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/tobythehutt/anyguard/internal/validation"
+	"github.com/tobythehutt/anyguard/v2/internal/validation"
 	"golang.org/x/tools/go/analysis"
 )
 

--- a/docs/golangci-lint/.custom-gcl.yml
+++ b/docs/golangci-lint/.custom-gcl.yml
@@ -2,6 +2,6 @@
 version: v2.7.2
 name: custom-gcl
 plugins:
-  - module: github.com/tobythehutt/anyguard
-    import: github.com/tobythehutt/anyguard/plugin
-    version: v2.0.1
+  - module: github.com/tobythehutt/anyguard/v2
+    import: github.com/tobythehutt/anyguard/v2/plugin
+    version: v2.0.2

--- a/docs/golangci-lint/README.md
+++ b/docs/golangci-lint/README.md
@@ -2,8 +2,8 @@
 
 ## Stable plugin entrypoint
 
-- Module path: `github.com/tobythehutt/anyguard`
-- Plugin import path: `github.com/tobythehutt/anyguard/plugin`
+- Module path: `github.com/tobythehutt/anyguard/v2`
+- Plugin import path: `github.com/tobythehutt/anyguard/v2/plugin`
 - Linter name in `.golangci.yml`: `anyguard`
 - Module-plugin diagnostics follow the same deterministic ordering compatibility guarantee as the CLI and public analyzer.
 - The plugin uses the same AST-slot-driven contract as the CLI and public analyzer.
@@ -21,6 +21,7 @@ golangci-lint custom
 ```
 
 This creates `./custom-gcl` by default.
+The checked-in [`docs/golangci-lint/.custom-gcl.yml`](.custom-gcl.yml) example uses the versioned `v2` module and plugin import paths.
 
 ## Enable the linter in `.golangci.yml`
 
@@ -117,6 +118,6 @@ For maintainers evaluating possible core inclusion:
 
 ## Release and version pinning
 
-- Keep `plugins[].version` pinned to the tag being released, for example `v2.0.1`.
+- Keep `plugins[].version` pinned to the tag being released, for example `v2.0.2`.
 - Module plugin support starts with `v1.0.0`. Do not pin below this version.
-- The plugin entrypoint import path `github.com/tobythehutt/anyguard/plugin` is stable and versioned with module tags.
+- The plugin entrypoint import path `github.com/tobythehutt/anyguard/v2/plugin` is stable and versioned with module tags.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tobythehutt/anyguard
+module github.com/tobythehutt/anyguard/v2
 
 go 1.22.0
 

--- a/internal/validation/benchmark_test.go
+++ b/internal/validation/benchmark_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/tobythehutt/anyguard/internal/benchtest"
+	"github.com/tobythehutt/anyguard/v2/internal/benchtest"
 	"golang.org/x/tools/go/analysis"
 )
 

--- a/internal/validation/execution_model_test.go
+++ b/internal/validation/execution_model_test.go
@@ -3,7 +3,7 @@ package validation
 import (
 	"testing"
 
-	"github.com/tobythehutt/anyguard/internal/benchtest"
+	"github.com/tobythehutt/anyguard/v2/internal/benchtest"
 	"golang.org/x/tools/go/analysis"
 )
 

--- a/internal/validation/repo_validation_cache_test.go
+++ b/internal/validation/repo_validation_cache_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tobythehutt/anyguard/internal/benchtest"
+	"github.com/tobythehutt/anyguard/v2/internal/benchtest"
 	"golang.org/x/tools/go/analysis"
 )
 

--- a/plugin/benchmark_test.go
+++ b/plugin/benchmark_test.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/tobythehutt/anyguard/internal/benchtest"
+	"github.com/tobythehutt/anyguard/v2/internal/benchtest"
 	"golang.org/x/tools/go/analysis"
 )
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/golangci/plugin-module-register/register"
-	"github.com/tobythehutt/anyguard/internal/validation"
+	"github.com/tobythehutt/anyguard/v2/internal/validation"
 	"golang.org/x/tools/go/analysis"
 )
 

--- a/scripts/ci/build-custom-gcl.sh
+++ b/scripts/ci/build-custom-gcl.sh
@@ -28,6 +28,10 @@ if [[ -z "${plugin_module}" ]]; then
 	echo "unable to resolve plugin module from .custom-gcl.yml" >&2
 	exit 1
 fi
+plugin_repo_module="${plugin_module}"
+if [[ "${plugin_repo_module}" =~ ^(.+)/v[0-9]+$ ]]; then
+	plugin_repo_module="${BASH_REMATCH[1]}"
+fi
 
 local_mod_dir="$(go list -m -f '{{.Dir}}' "github.com/golangci/golangci-lint/v2@${custom_version}")"
 if [[ -z "${local_mod_dir}" || ! -d "${local_mod_dir}" ]]; then
@@ -92,8 +96,8 @@ git clone --bare -q "${plugin_worktree}" "${plugin_repo}"
 export GIT_CONFIG_GLOBAL="${tmp_root}/gitconfig"
 touch "${GIT_CONFIG_GLOBAL}"
 git config --global url."file://${local_repo}".insteadOf "https://github.com/golangci/golangci-lint.git"
-git config --global url."file://${plugin_repo}".insteadOf "https://${plugin_module}.git"
-git config --global url."file://${plugin_repo}".insteadOf "https://${plugin_module}"
+git config --global url."file://${plugin_repo}".insteadOf "https://${plugin_repo_module}.git"
+git config --global url."file://${plugin_repo}".insteadOf "https://${plugin_repo_module}"
 
 append_csv_env() {
 	local key="$1"
@@ -110,6 +114,7 @@ append_csv_env() {
 	export "${key}=${current},${value}"
 }
 
+append_csv_env GOPRIVATE "${plugin_repo_module}"
 append_csv_env GOPRIVATE "${plugin_module}"
 export GOPROXY="https://proxy.golang.org,direct"
 

--- a/testdata/golangci/.custom-gcl.yml
+++ b/testdata/golangci/.custom-gcl.yml
@@ -1,6 +1,6 @@
 version: v2.7.2
 name: custom-gcl
 plugins:
-  - module: github.com/tobythehutt/anyguard
-    import: github.com/tobythehutt/anyguard/plugin
-    version: v2.0.1
+  - module: github.com/tobythehutt/anyguard/v2
+    import: github.com/tobythehutt/anyguard/v2/plugin
+    version: v2.0.2


### PR DESCRIPTION
## Summary

- change the module path to `github.com/tobythehutt/anyguard/v2` and update self-imports
- update README, golangci-lint docs, and checked-in custom-gcl fixtures to use `/v2`
- fix the custom golangci-lint builder so semantic-major module paths still resolve through the unsuffixed GitHub repo root
- record the change under the new `v2.0.2` changelog entry

Resolves: #63 
