### PR TITLE
chore(release): configure generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,39 @@
+# GitHub uses this file only for generated GitHub Release notes.
+# Keep CHANGELOG.md as the curated project release history.
+---
+changelog:
+  exclude:
+    labels:
+      - "skip-release-notes"
+      - "release-note:skip"
+    authors:
+      - "dependabot[bot]"
+      - "github-actions[bot]"
+  categories:
+    - title: "Breaking Changes"
+      labels:
+        - "breaking-change"
+        - "semver-major"
+    - title: "Features"
+      labels:
+        - "enhancement"
+        - "feature"
+        - "semver-minor"
+    - title: "Fixes"
+      labels:
+        - "bug"
+        - "fix"
+    - title: "Documentation"
+      labels:
+        - "documentation"
+        - "docs"
+    - title: "Maintenance"
+      labels:
+        - "maintenance"
+        - "chore"
+        - "ci"
+        - "refactor"
+        - "dependencies"
+    - title: "Other Changes"
+      labels:
+        - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, with the current development state trac
 
 ## [Unreleased]
 
+### Added
+
+- Added GitHub generated release-note configuration and label guidance without replacing the curated changelog. (@TobyTheHutt)
+
 ## [2.0.2] - 2026-03-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ A Go analyzer and CLI that controls where `any` can be used.
 
 Release history lives in [`CHANGELOG.md`](CHANGELOG.md).
 
+### GitHub Release Notes
+
+GitHub-generated release notes are configured in [`.github/release.yml`](.github/release.yml). That file only controls the generated GitHub Release UI and Releases API output.
+
+Apply one of these labels to each merged pull request when generated release notes should place it in a specific section:
+
+| Generated section | Labels |
+| --- | --- |
+| Breaking Changes | `breaking-change`, `semver-major` |
+| Features | `enhancement`, `feature`, `semver-minor` |
+| Fixes | `bug`, `fix` |
+| Documentation | `documentation`, `docs` |
+| Maintenance | `maintenance`, `chore`, `ci`, `refactor`, `dependencies` |
+| Other Changes | any merged pull request that does not match an earlier section |
+
+Use `skip-release-notes` or `release-note:skip` for pull requests that should stay out of generated release notes. Automation-only pull requests from `dependabot[bot]` and `github-actions[bot]` are excluded as release-note noise; label human-reviewed dependency, CI, or refactor work as `maintenance` when it should appear.
+
 ### Why
 
 `any` is useful at boundaries but unchecked usage spreads quickly and weakens type safety.  


### PR DESCRIPTION
## Summary

Adds repository-level configuration for GitHub-generated release notes.

This PR adds `.github/release.yml` so GitHub Release notes are grouped consistently when maintainers use `Generate release notes` in the Release UI or Releases API. The config defines release-note categories for breaking changes, features, fixes, documentation, maintenance, and uncategorized changes.

It also documents the label conventions in the README and clarifies that generated GitHub Release notes do not replace the curated project changelog.

Resolves: #45 

## Changes

- Add `.github/release.yml` for GitHub autogenerated release notes.
- Group merged PRs into:
  - Breaking Changes
  - Features
  - Fixes
  - Documentation
  - Maintenance
  - Other Changes
- Add a catch-all category with `labels: ["*"]`.
- Exclude obvious release-note noise:
  - `skip-release-notes`
  - `release-note:skip`
  - `dependabot[bot]`
  - `github-actions[bot]`
- Document release-note label conventions in `README.md`.
- Add an Unreleased changelog entry.

## Notes

This only affects GitHub-generated Release notes. It does not replace `CHANGELOG.md` or any future long-form release-note process.