### PR TITLE
49 automatic release tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+    types: [opened, synchronize, reopened, edited]
   push:
     branches: [main]
 
@@ -28,7 +28,6 @@ jobs:
       - name: Validate release metadata
         env:
           RELEASE_MODE: validate-pr
-          RELEASE_PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           RELEASE_PR_TITLE: ${{ github.event.pull_request.title }}
         run: bash ./scripts/ci/prepare-github-release.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+  push:
+    branches: [main]
+
+concurrency:
+  group: release-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate-release-pr:
+    name: Validate Release PR
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate release metadata
+        env:
+          RELEASE_MODE: validate-pr
+          RELEASE_PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          RELEASE_PR_TITLE: ${{ github.event.pull_request.title }}
+        run: bash ./scripts/ci/prepare-github-release.sh
+
+  release:
+    name: Tag And Publish Release
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare release metadata
+        id: release
+        run: bash ./scripts/ci/prepare-github-release.sh
+
+      - name: Create release tag
+        if: steps.release.outputs.release_detected == 'true' && steps.release.outputs.tag_exists == 'false'
+        run: |
+          release_tag="${{ steps.release.outputs.tag }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag --annotate --message "Release ${release_tag}" "${release_tag}" "${GITHUB_SHA}"
+          git push origin "refs/tags/${release_tag}"
+
+      - name: Check GitHub release
+        id: github_release
+        if: steps.release.outputs.release_detected == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          release_tag="${{ steps.release.outputs.tag }}"
+          release_exists="false"
+
+          if gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            release_exists="true"
+          fi
+
+          printf 'release_exists=%s\n' "${release_exists}" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish GitHub release
+        if: steps.release.outputs.release_detected == 'true' && steps.github_release.outputs.release_exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          release_body_file="${{ steps.release.outputs.body_file }}"
+          release_tag="${{ steps.release.outputs.tag }}"
+
+          gh release create "${release_tag}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${release_tag}" \
+            --notes-file "${release_body_file}" \
+            --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog, with the current development state trac
 
 ### Added
 
+- Added an automated release workflow that validates release-prep pull requests, tags the final `main` commit after merge, and publishes the GitHub release from the curated changelog body. (@TobyTheHutt)
 - Added GitHub generated release-note configuration and label guidance without replacing the curated changelog. (@TobyTheHutt)
 
 ## [2.0.2] - 2026-03-22

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ A Go analyzer and CLI that controls where `any` can be used.
 
 Release history lives in [`CHANGELOG.md`](CHANGELOG.md).
 
+### Automated Releases
+
+Release-prep pull requests may be squash-merged. The [`Release`](.github/workflows/release.yml) workflow validates release-prep pull requests before merge, then runs again after the final commit lands on `main`, creates the `vX.Y.Z` tag on that commit, and publishes the GitHub release with the changelog entry as the release body.
+
+Use a pull request or squash commit title of `release: vX.Y.Z`, add the `release` label, or make the top `CHANGELOG.md` release heading change to a new dated section. Release pull requests fail early when the version is malformed, the changelog entry is inconsistent, or the tag already exists. After merge, if a matching tag already exists on a different commit, the workflow fails instead of moving it.
+
 ### GitHub Release Notes
 
 GitHub-generated release notes are configured in [`.github/release.yml`](.github/release.yml). That file only controls the generated GitHub Release UI and Releases API output.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Release history lives in [`CHANGELOG.md`](CHANGELOG.md).
 
 Release-prep pull requests may be squash-merged. The [`Release`](.github/workflows/release.yml) workflow validates release-prep pull requests before merge, then runs again after the final commit lands on `main`, creates the `vX.Y.Z` tag on that commit, and publishes the GitHub release with the changelog entry as the release body.
 
-Use a pull request or squash commit title of `release: vX.Y.Z`, add the `release` label, or make the top `CHANGELOG.md` release heading change to a new dated section. Release pull requests fail early when the version is malformed, the changelog entry is inconsistent, or the tag already exists. After merge, if a matching tag already exists on a different commit, the workflow fails instead of moving it.
+Use a pull request or squash commit title of `release: vX.Y.Z`, or make the top `CHANGELOG.md` release heading change to a new dated section. Release pull requests fail early when the version tag is malformed, the changelog entry is inconsistent, or the version tag already exists. After merge, if a matching version tag already exists on a different commit, the workflow fails instead of moving it.
 
 ### GitHub Release Notes
 

--- a/scripts/ci/prepare-github-release.sh
+++ b/scripts/ci/prepare-github-release.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+release_mode="${RELEASE_MODE:-publish}"
+changelog_path="${1:-CHANGELOG.md}"
+release_notes_root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/anyguard-release"
+release_heading_pattern='^##[[:space:]]+\[v?([0-9]+\.[0-9]+\.[0-9]+)\][[:space:]]+-[[:space:]]+([0-9]{4}-[0-9]{2}-[0-9]{2})$'
+release_subject_pattern='^release:[[:space:]]+(v[0-9]+\.[0-9]+\.[0-9]+)$'
+
+top_release_heading_awk() {
+	cat <<'AWK'
+	$0 == "## [Unreleased]" {
+		after_unreleased = 1
+		next
+	}
+	after_unreleased && /^## / {
+		print
+		exit
+	}
+AWK
+}
+
+fail() {
+	local message="$1"
+
+	echo "release preparation failed: ${message}" >&2
+	exit 1
+}
+
+set_action_output() {
+	local name="$1"
+	local value="$2"
+
+	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+		printf '%s=%s\n' "${name}" "${value}" >> "${GITHUB_OUTPUT}"
+	fi
+
+	printf '%s=%s\n' "${name}" "${value}"
+}
+
+read_current_commit_subject() {
+	git log -1 --pretty='%s'
+}
+
+read_release_signal_title() {
+	if [[ "${release_mode}" == "validate-pr" && -n "${RELEASE_PR_TITLE:-}" ]]; then
+		printf '%s\n' "${RELEASE_PR_TITLE}"
+		return
+	fi
+
+	read_current_commit_subject
+}
+
+read_top_release_heading_from_file() {
+	local file_path="$1"
+
+	awk "$(top_release_heading_awk)" "${file_path}"
+}
+
+read_previous_top_release_heading() {
+	local file_path="$1"
+	local parent_changelog_ref="HEAD^:${file_path}"
+
+	if ! git cat-file -e "${parent_changelog_ref}" 2>/dev/null; then
+		return 0
+	fi
+
+	git show "${parent_changelog_ref}" | awk "$(top_release_heading_awk)"
+}
+
+read_release_body() {
+	local file_path="$1"
+
+	awk '
+		$0 == "## [Unreleased]" {
+			after_unreleased = 1
+			next
+		}
+		after_unreleased && /^## / && ! in_release {
+			in_release = 1
+			next
+		}
+		in_release && /^## / {
+			exit
+		}
+		in_release {
+			lines[++line_count] = $0
+		}
+		END {
+			first_line = 1
+			last_line = line_count
+
+			while (first_line <= last_line && lines[first_line] == "") {
+				first_line++
+			}
+			while (last_line >= first_line && lines[last_line] == "") {
+				last_line--
+			}
+			for (line = first_line; line <= last_line; line++) {
+				print lines[line]
+			}
+		}
+	' "${file_path}"
+}
+
+read_remote_tag_status() {
+	local release_tag="$1"
+	local tag_ref="refs/tags/${release_tag}"
+	local status
+
+	if ! git remote get-url origin >/dev/null 2>&1; then
+		printf 'missing\n'
+		return
+	fi
+
+	if git ls-remote --exit-code --tags origin "${tag_ref}" >/dev/null 2>&1; then
+		printf 'exists\n'
+		return
+	fi
+
+	status="$?"
+	if [[ "${status}" == "2" ]]; then
+		printf 'missing\n'
+		return
+	fi
+
+	printf 'error\n'
+}
+
+changelog_changed_in_head() {
+	local file_path="$1"
+
+	if ! git rev-parse --verify --quiet HEAD^ >/dev/null; then
+		printf 'false\n'
+		return
+	fi
+
+	if git diff --quiet HEAD^ HEAD -- "${file_path}"; then
+		printf 'false\n'
+		return
+	fi
+
+	printf 'true\n'
+}
+
+release_label_is_set() {
+	local labels="${RELEASE_PR_LABELS:-}"
+	local label
+	local trimmed_label
+
+	if [[ "${release_mode}" != "validate-pr" ]]; then
+		printf 'false\n'
+		return
+	fi
+
+	IFS=',' read -r -a label_names <<< "${labels}"
+	for label in "${label_names[@]}"; do
+		trimmed_label="$(printf '%s' "${label}" | xargs)"
+
+		if [[ "${trimmed_label}" == "release" ]]; then
+			printf 'true\n'
+			return
+		fi
+	done
+
+	printf 'false\n'
+}
+
+extract_release_tag_from_subject() {
+	local commit_subject="$1"
+
+	if [[ "${commit_subject}" =~ ${release_subject_pattern} ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"
+		return
+	fi
+
+	if [[ "${commit_subject}" == release:* ]]; then
+		fail "release commit subject must match 'release: vX.Y.Z', got '${commit_subject}'"
+	fi
+}
+
+parse_release_heading() {
+	local release_heading="$1"
+
+	if [[ ! "${release_heading}" =~ ${release_heading_pattern} ]]; then
+		return 1
+	fi
+
+	printf 'v%s|%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+}
+
+tag_exists_locally() {
+	local release_tag="$1"
+	local tag_ref="refs/tags/${release_tag}"
+
+	git show-ref --tags --verify --quiet "${tag_ref}"
+}
+
+fetch_remote_tag() {
+	local release_tag="$1"
+	local tag_ref="refs/tags/${release_tag}"
+
+	git fetch --force --no-tags origin "${tag_ref}:${tag_ref}" >/dev/null
+}
+
+read_tag_commit() {
+	local release_tag="$1"
+	local tag_ref="refs/tags/${release_tag}"
+
+	git rev-parse "${tag_ref}^{commit}"
+}
+
+require_tag_available_for_pr() {
+	local release_tag="$1"
+	local local_tag_exists="false"
+	local remote_tag_status
+
+	remote_tag_status="$(read_remote_tag_status "${release_tag}")"
+	if [[ "${remote_tag_status}" == "error" ]]; then
+		fail "unable to verify whether tag ${release_tag} exists on origin"
+	fi
+	if tag_exists_locally "${release_tag}"; then
+		local_tag_exists="true"
+	fi
+	if [[ "${remote_tag_status}" == "exists" || "${local_tag_exists}" == "true" ]]; then
+		fail "tag ${release_tag} already exists; choose an unreleased version"
+	fi
+}
+
+require_existing_tag_matches_head() {
+	local release_tag="$1"
+	local existing_tag_commit
+	local head_commit
+	local remote_tag_status
+
+	remote_tag_status="$(read_remote_tag_status "${release_tag}")"
+	if [[ "${remote_tag_status}" == "error" ]]; then
+		fail "unable to verify whether tag ${release_tag} exists on origin"
+	fi
+	if [[ "${remote_tag_status}" == "exists" ]]; then
+		if ! fetch_remote_tag "${release_tag}"; then
+			fail "unable to fetch existing remote tag ${release_tag}"
+		fi
+	fi
+
+	if ! tag_exists_locally "${release_tag}"; then
+		printf 'false\n'
+		return
+	fi
+
+	# Re-runs are allowed only when the existing tag already peels to HEAD.
+	head_commit="$(git rev-parse HEAD)"
+	existing_tag_commit="$(read_tag_commit "${release_tag}")"
+	if [[ "${existing_tag_commit}" != "${head_commit}" ]]; then
+		fail "tag ${release_tag} points to ${existing_tag_commit}, expected ${head_commit}"
+	fi
+
+	printf 'true\n'
+}
+
+write_skip_outputs() {
+	set_action_output "release_detected" "false"
+	set_action_output "tag" ""
+	set_action_output "date" ""
+	set_action_output "body_file" ""
+	set_action_output "tag_exists" "false"
+}
+
+mkdir -p "${release_notes_root}"
+
+if [[ "${release_mode}" != "publish" && "${release_mode}" != "validate-pr" ]]; then
+	fail "unsupported release mode ${release_mode}"
+fi
+
+if [[ ! -f "${changelog_path}" ]]; then
+	fail "${changelog_path} does not exist"
+fi
+
+release_signal_title="$(read_release_signal_title)"
+subject_release_tag="$(extract_release_tag_from_subject "${release_signal_title}")"
+current_release_heading="$(read_top_release_heading_from_file "${changelog_path}")"
+previous_release_heading="$(read_previous_top_release_heading "${changelog_path}")"
+changelog_changed="$(changelog_changed_in_head "${changelog_path}")"
+changelog_heading_changed="false"
+release_label_detected="$(release_label_is_set)"
+
+if [[ "${changelog_changed}" == "true" && "${current_release_heading}" != "${previous_release_heading}" ]]; then
+	changelog_heading_changed="true"
+fi
+
+if [[ -z "${subject_release_tag}" && "${release_label_detected}" == "false" && "${changelog_heading_changed}" == "false" ]]; then
+	write_skip_outputs
+	exit 0
+fi
+
+if [[ -z "${current_release_heading}" ]]; then
+	fail "${changelog_path} does not contain a release section after Unreleased"
+fi
+
+if ! parsed_release_heading="$(parse_release_heading "${current_release_heading}")"; then
+	fail "top changelog release heading is malformed: ${current_release_heading}"
+fi
+
+release_tag="${parsed_release_heading%%|*}"
+release_date="${parsed_release_heading#*|}"
+
+if [[ -n "${subject_release_tag}" && "${subject_release_tag}" != "${release_tag}" ]]; then
+	fail "release subject tag ${subject_release_tag} does not match changelog tag ${release_tag}"
+fi
+
+release_body="$(read_release_body "${changelog_path}")"
+release_body_file="${release_notes_root}/${release_tag}.md"
+
+printf '%s\n' "${release_body}" > "${release_body_file}"
+
+if ! grep -q '[^[:space:]]' "${release_body_file}"; then
+	fail "top changelog release section ${release_tag} has an empty body"
+fi
+
+# PR validation must prove the version is unused before the post-merge tag exists.
+if [[ "${release_mode}" == "validate-pr" ]]; then
+	require_tag_available_for_pr "${release_tag}"
+	set_action_output "release_detected" "true"
+	set_action_output "tag" "${release_tag}"
+	set_action_output "date" "${release_date}"
+	set_action_output "body_file" "${release_body_file}"
+	set_action_output "tag_exists" "false"
+	exit 0
+fi
+
+# Publish mode permits reruns only when the existing tag already resolves to HEAD.
+release_tag_exists="$(require_existing_tag_matches_head "${release_tag}")"
+
+set_action_output "release_detected" "true"
+set_action_output "tag" "${release_tag}"
+set_action_output "date" "${release_date}"
+set_action_output "body_file" "${release_body_file}"
+set_action_output "tag_exists" "${release_tag_exists}"

--- a/scripts/ci/prepare-github-release.sh
+++ b/scripts/ci/prepare-github-release.sh
@@ -143,29 +143,6 @@ changelog_changed_in_head() {
 	printf 'true\n'
 }
 
-release_label_is_set() {
-	local labels="${RELEASE_PR_LABELS:-}"
-	local label
-	local trimmed_label
-
-	if [[ "${release_mode}" != "validate-pr" ]]; then
-		printf 'false\n'
-		return
-	fi
-
-	IFS=',' read -r -a label_names <<< "${labels}"
-	for label in "${label_names[@]}"; do
-		trimmed_label="$(printf '%s' "${label}" | xargs)"
-
-		if [[ "${trimmed_label}" == "release" ]]; then
-			printf 'true\n'
-			return
-		fi
-	done
-
-	printf 'false\n'
-}
-
 extract_release_tag_from_subject() {
 	local commit_subject="$1"
 
@@ -282,13 +259,12 @@ current_release_heading="$(read_top_release_heading_from_file "${changelog_path}
 previous_release_heading="$(read_previous_top_release_heading "${changelog_path}")"
 changelog_changed="$(changelog_changed_in_head "${changelog_path}")"
 changelog_heading_changed="false"
-release_label_detected="$(release_label_is_set)"
 
 if [[ "${changelog_changed}" == "true" && "${current_release_heading}" != "${previous_release_heading}" ]]; then
 	changelog_heading_changed="true"
 fi
 
-if [[ -z "${subject_release_tag}" && "${release_label_detected}" == "false" && "${changelog_heading_changed}" == "false" ]]; then
+if [[ -z "${subject_release_tag}" && "${changelog_heading_changed}" == "false" ]]; then
 	write_skip_outputs
 	exit 0
 fi

--- a/scripts/ci/prepare_github_release_test.go
+++ b/scripts/ci/prepare_github_release_test.go
@@ -1,0 +1,525 @@
+package ci_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	changelogFile      = "CHANGELOG.md"
+	gitAddCommand      = "add"
+	gitCommand         = "git"
+	gitConfigCommand   = "config"
+	gitInitCommand     = "init"
+	gitOriginRemote    = "origin"
+	gitTagCommand      = "tag"
+	githubOutputFile   = "github-output"
+	modeValidatePR     = "validate-pr"
+	notesCommitMessage = "docs: update notes"
+	notesContent       = "ordinary documentation update\n"
+	notesFile          = "NOTES.md"
+	outputBodyFile     = "body_file"
+	outputDate         = "date"
+	outputFalse        = "false"
+	outputRelease      = "release_detected"
+	outputTag          = "tag"
+	outputTagExists    = "tag_exists"
+	outputTrue         = "true"
+	releaseBody        = "### Added\n\n- Added automated release tagging."
+	releaseDate        = "2026-04-14"
+	releaseTag         = "v1.1.0"
+	releaseVersion     = "1.1.0"
+	releaseModeEnv     = "RELEASE_MODE"
+	releaseNotesCommit = "docs: prepare release notes"
+	releasePRLabelsEnv = "RELEASE_PR_LABELS"
+	releasePRTitleEnv  = "RELEASE_PR_TITLE"
+	scriptTimeout      = 15 * time.Second
+	seedCommitMessage  = "docs: seed changelog"
+	tagExistsFragment  = "already exists"
+	releaseCommitTitle = "release: v1.1.0"
+)
+
+type releaseRepo struct {
+	dir        string
+	scriptPath string
+}
+
+type prepareOutput struct {
+	bodyFile        string
+	date            string
+	releaseDetected string
+	tag             string
+	tagExists       string
+}
+
+func TestPrepareGitHubReleaseDetectsReleaseSubject(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	repo.writeChangelog(t, changelogWithTopRelease(releaseVersion, releaseBody))
+	repo.commit(t, releaseCommitTitle)
+
+	output := repo.requirePrepareSuccess(t)
+
+	requireOutputValue(t, output.releaseDetected, outputTrue, outputRelease)
+	requireOutputValue(t, output.tag, releaseTag, outputTag)
+	requireOutputValue(t, output.date, releaseDate, outputDate)
+	requireOutputValue(t, output.tagExists, outputFalse, outputTagExists)
+	requireReleaseBody(t, output.bodyFile, releaseBody)
+}
+
+func TestPrepareGitHubReleaseDetectsChangelogRelease(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	repo.writeChangelog(t, changelogWithTopRelease(releaseVersion, releaseBody))
+	repo.commit(t, "docs: finalize release notes")
+
+	output := repo.requirePrepareSuccess(t)
+
+	requireOutputValue(t, output.releaseDetected, outputTrue, outputRelease)
+	requireOutputValue(t, output.tag, releaseTag, outputTag)
+	requireReleaseBody(t, output.bodyFile, releaseBody)
+}
+
+func TestPrepareGitHubReleaseSkipsNormalCommit(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	writeFile(t, repo.dir, notesFile, notesContent)
+	repo.commit(t, notesCommitMessage)
+
+	output := repo.requirePrepareSuccess(t)
+
+	requireOutputValue(t, output.releaseDetected, outputFalse, outputRelease)
+	requireOutputValue(t, output.tag, "", outputTag)
+	requireOutputValue(t, output.tagExists, outputFalse, outputTagExists)
+}
+
+func TestPrepareGitHubReleaseValidatesReleasePRTitle(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	repo.writeChangelog(t, changelogWithTopRelease(releaseVersion, releaseBody))
+	repo.commit(t, releaseNotesCommit)
+
+	output := repo.requirePrepareSuccess(t, validatePREnvironment(releaseCommitTitle)...)
+
+	requireOutputValue(t, output.releaseDetected, outputTrue, outputRelease)
+	requireOutputValue(t, output.tag, releaseTag, outputTag)
+	requireOutputValue(t, output.date, releaseDate, outputDate)
+	requireOutputValue(t, output.tagExists, outputFalse, outputTagExists)
+	requireReleaseBody(t, output.bodyFile, releaseBody)
+}
+
+func TestPrepareGitHubReleaseValidatesReleasePRLabel(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	repo.writeChangelog(t, changelogWithTopRelease(releaseVersion, releaseBody))
+	repo.commit(t, releaseNotesCommit)
+
+	output := repo.requirePrepareSuccess(
+		t,
+		envAssignment(releaseModeEnv, modeValidatePR),
+		envAssignment(releasePRLabelsEnv, "documentation,release"),
+	)
+
+	requireOutputValue(t, output.releaseDetected, outputTrue, outputRelease)
+	requireOutputValue(t, output.tag, releaseTag, outputTag)
+	requireReleaseBody(t, output.bodyFile, releaseBody)
+}
+
+func TestPrepareGitHubReleaseValidatesReleasePRChangelog(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	repo.writeChangelog(t, changelogWithTopRelease(releaseVersion, releaseBody))
+	repo.commit(t, releaseNotesCommit)
+
+	output := repo.requirePrepareSuccess(t, envAssignment(releaseModeEnv, modeValidatePR))
+
+	requireOutputValue(t, output.releaseDetected, outputTrue, outputRelease)
+	requireOutputValue(t, output.tag, releaseTag, outputTag)
+	requireReleaseBody(t, output.bodyFile, releaseBody)
+}
+
+func TestPrepareGitHubReleaseSkipsNormalPR(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	writeFile(t, repo.dir, notesFile, notesContent)
+	repo.commit(t, notesCommitMessage)
+
+	output := repo.requirePrepareSuccess(t, envAssignment(releaseModeEnv, modeValidatePR))
+
+	requireOutputValue(t, output.releaseDetected, outputFalse, outputRelease)
+	requireOutputValue(t, output.tag, "", outputTag)
+	requireOutputValue(t, output.tagExists, outputFalse, outputTagExists)
+}
+
+func TestPrepareGitHubReleaseRejectsMalformedReleasePRTitle(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	combinedOutput := repo.requirePrepareFailure(t, validatePREnvironment("release: 1.1.0")...)
+
+	if !strings.Contains(combinedOutput, "must match 'release: vX.Y.Z'") {
+		t.Fatalf("expected malformed release PR title failure, got:\n%s", combinedOutput)
+	}
+}
+
+func TestPrepareGitHubReleaseRejectsReleasePRLocalTagConflict(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	runCommand(t, repo.dir, gitCommand, gitTagCommand, releaseTag)
+	repo.writeChangelog(t, changelogWithTopRelease(releaseVersion, releaseBody))
+	repo.commit(t, releaseNotesCommit)
+
+	combinedOutput := repo.requirePrepareFailure(t, validatePREnvironment(releaseCommitTitle)...)
+
+	if !strings.Contains(combinedOutput, tagExistsFragment) {
+		t.Fatalf("expected local tag conflict failure, got:\n%s", combinedOutput)
+	}
+}
+
+func TestPrepareGitHubReleaseRejectsReleasePRRemoteTagConflict(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	repo.addOriginWithTag(t, releaseTag)
+	repo.writeChangelog(t, changelogWithTopRelease(releaseVersion, releaseBody))
+	repo.commit(t, releaseNotesCommit)
+
+	combinedOutput := repo.requirePrepareFailure(t, validatePREnvironment(releaseCommitTitle)...)
+
+	if !strings.Contains(combinedOutput, tagExistsFragment) {
+		t.Fatalf("expected remote tag conflict failure, got:\n%s", combinedOutput)
+	}
+}
+
+func TestPrepareGitHubReleaseRejectsSubjectChangelogMismatch(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	repo.writeChangelog(t, changelogWithTopRelease(releaseVersion, releaseBody))
+	repo.commit(t, "release: v1.2.0")
+
+	combinedOutput := repo.requirePrepareFailure(t)
+
+	if !strings.Contains(combinedOutput, "does not match changelog tag") {
+		t.Fatalf("expected mismatch failure, got:\n%s", combinedOutput)
+	}
+}
+
+func TestPrepareGitHubReleaseRejectsMalformedTopHeading(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	malformedChangelog := changelogWithMalformedTopRelease(releaseBody)
+	repo.writeChangelog(t, malformedChangelog)
+	repo.commit(t, "docs: finalize malformed release notes")
+
+	combinedOutput := repo.requirePrepareFailure(t)
+
+	if !strings.Contains(combinedOutput, "top changelog release heading is malformed") {
+		t.Fatalf("expected malformed heading failure, got:\n%s", combinedOutput)
+	}
+}
+
+func TestPrepareGitHubReleaseRejectsEmptyReleaseBody(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	repo.writeChangelog(t, changelogWithTopRelease(releaseVersion, ""))
+	repo.commit(t, releaseCommitTitle)
+
+	combinedOutput := repo.requirePrepareFailure(t)
+
+	if !strings.Contains(combinedOutput, "empty body") {
+		t.Fatalf("expected empty release body failure, got:\n%s", combinedOutput)
+	}
+}
+
+func TestPrepareGitHubReleaseRejectsMissingChangelog(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	removeFile(t, repo.dir, changelogFile)
+	repo.commit(t, releaseCommitTitle)
+
+	combinedOutput := repo.requirePrepareFailure(t)
+
+	if !strings.Contains(combinedOutput, changelogFile+" does not exist") {
+		t.Fatalf("expected missing changelog failure, got:\n%s", combinedOutput)
+	}
+}
+
+func TestPrepareGitHubReleaseAcceptsExistingTagOnHead(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	repo.writeChangelog(t, changelogWithTopRelease(releaseVersion, releaseBody))
+	repo.commit(t, releaseCommitTitle)
+	runCommand(t, repo.dir, gitCommand, gitTagCommand, releaseTag)
+
+	output := repo.requirePrepareSuccess(t)
+
+	requireOutputValue(t, output.releaseDetected, outputTrue, outputRelease)
+	requireOutputValue(t, output.tagExists, outputTrue, outputTagExists)
+}
+
+func TestPrepareGitHubReleaseRejectsExistingTagOffHead(t *testing.T) {
+	repo := newReleaseRepo(t)
+
+	runCommand(t, repo.dir, gitCommand, gitTagCommand, releaseTag)
+	repo.writeChangelog(t, changelogWithTopRelease(releaseVersion, releaseBody))
+	repo.commit(t, releaseCommitTitle)
+
+	combinedOutput := repo.requirePrepareFailure(t)
+
+	if !strings.Contains(combinedOutput, "tag "+releaseTag+" points to") {
+		t.Fatalf("expected wrong-commit tag failure, got:\n%s", combinedOutput)
+	}
+}
+
+func newReleaseRepo(t *testing.T) releaseRepo {
+	t.Helper()
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("read test working directory: %v", err)
+	}
+
+	repo := releaseRepo{
+		dir:        t.TempDir(),
+		scriptPath: filepath.Join(workingDir, "prepare-github-release.sh"),
+	}
+
+	runCommand(t, repo.dir, gitCommand, gitInitCommand, "-q")
+	runCommand(t, repo.dir, gitCommand, "checkout", "-q", "-b", "main")
+	runCommand(t, repo.dir, gitCommand, gitConfigCommand, "user.email", "ci@example.invalid")
+	runCommand(t, repo.dir, gitCommand, gitConfigCommand, "user.name", "CI")
+
+	repo.writeChangelog(t, changelogWithTopRelease("1.0.0", "### Added\n\n- Seed release."))
+	repo.commit(t, seedCommitMessage)
+
+	return repo
+}
+
+func (repo releaseRepo) writeChangelog(t *testing.T, content string) {
+	t.Helper()
+
+	writeFile(t, repo.dir, changelogFile, content)
+}
+
+func (repo releaseRepo) commit(t *testing.T, message string) {
+	t.Helper()
+
+	runCommand(t, repo.dir, gitCommand, gitAddCommand, ".")
+	runCommand(t, repo.dir, gitCommand, "commit", "-q", "-m", message)
+}
+
+func (repo releaseRepo) addOriginWithTag(t *testing.T, tag string) {
+	t.Helper()
+
+	originDir := t.TempDir()
+
+	runCommand(t, originDir, gitCommand, gitInitCommand, "--bare", "-q")
+	runCommand(t, repo.dir, gitCommand, "remote", gitAddCommand, gitOriginRemote, originDir)
+	runCommand(t, repo.dir, gitCommand, gitTagCommand, tag)
+	runCommand(t, repo.dir, gitCommand, "push", gitOriginRemote, "refs/tags/"+tag)
+	runCommand(t, repo.dir, gitCommand, gitTagCommand, "-d", tag)
+}
+
+func (repo releaseRepo) requirePrepareSuccess(t *testing.T, environment ...string) prepareOutput {
+	t.Helper()
+
+	output, combinedOutput, err := repo.runPrepare(t, environment...)
+	if err != nil {
+		t.Fatalf("prepare script failed: %v\n%s", err, combinedOutput)
+	}
+
+	return output
+}
+
+func (repo releaseRepo) requirePrepareFailure(t *testing.T, environment ...string) string {
+	t.Helper()
+
+	_, combinedOutput, err := repo.runPrepare(t, environment...)
+	if err == nil {
+		t.Fatalf("prepare script unexpectedly passed:\n%s", combinedOutput)
+	}
+
+	return combinedOutput
+}
+
+func (repo releaseRepo) runPrepare(t *testing.T, environment ...string) (prepareOutput, string, error) {
+	t.Helper()
+
+	outputPath := filepath.Join(repo.dir, githubOutputFile)
+	ctx, cancel := context.WithTimeout(context.Background(), scriptTimeout)
+	defer cancel()
+
+	//nolint:gosec // The test executes a repository-local script against a temp git repository.
+	command := exec.CommandContext(ctx, "bash", repo.scriptPath)
+	command.Dir = repo.dir
+	command.Env = append(os.Environ(), "GITHUB_OUTPUT="+outputPath, "RUNNER_TEMP="+repo.dir)
+	command.Env = append(command.Env, environment...)
+
+	combinedOutputBytes, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("prepare script timed out: %v", ctx.Err())
+	}
+
+	output := readPrepareOutput(t, outputPath)
+	combinedOutput := string(combinedOutputBytes)
+
+	return output, combinedOutput, err
+}
+
+func validatePREnvironment(title string) []string {
+	return []string{
+		envAssignment(releaseModeEnv, modeValidatePR),
+		envAssignment(releasePRTitleEnv, title),
+	}
+}
+
+func envAssignment(name string, value string) string {
+	return name + "=" + value
+}
+
+func readPrepareOutput(t *testing.T, outputPath string) prepareOutput {
+	t.Helper()
+
+	//nolint:gosec // The path is generated inside the test's temp repository.
+	outputBytes, err := os.ReadFile(outputPath)
+	if os.IsNotExist(err) {
+		return prepareOutput{}
+	}
+	if err != nil {
+		t.Fatalf("read GitHub output file: %v", err)
+	}
+
+	return parsePrepareOutput(string(outputBytes))
+}
+
+func parsePrepareOutput(content string) prepareOutput {
+	var output prepareOutput
+
+	lines := strings.Split(strings.TrimSpace(content), "\n")
+	for _, line := range lines {
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+
+		switch key {
+		case outputBodyFile:
+			output.bodyFile = value
+		case outputDate:
+			output.date = value
+		case outputRelease:
+			output.releaseDetected = value
+		case outputTag:
+			output.tag = value
+		case outputTagExists:
+			output.tagExists = value
+		}
+	}
+
+	return output
+}
+
+func requireReleaseBody(t *testing.T, bodyFile string, want string) {
+	t.Helper()
+
+	//nolint:gosec // The path comes from the test-owned release helper output.
+	bodyBytes, err := os.ReadFile(bodyFile)
+	if err != nil {
+		t.Fatalf("read release body file: %v", err)
+	}
+
+	got := strings.TrimSpace(string(bodyBytes))
+	if got != want {
+		t.Fatalf("unexpected release body:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func requireOutputValue(t *testing.T, got string, want string, name string) {
+	t.Helper()
+
+	if got != want {
+		t.Fatalf("unexpected %s: got %q want %q", name, got, want)
+	}
+}
+
+func changelogWithTopRelease(version string, body string) string {
+	return fmt.Sprintf(`# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## [%s] - %s
+
+%s
+
+## [0.9.0] - 2026-04-01
+
+### Added
+
+- Older release.
+`, version, releaseDate, body)
+}
+
+func changelogWithMalformedTopRelease(body string) string {
+	return fmt.Sprintf(`# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## [1.1] - %s
+
+%s
+
+## [0.9.0] - 2026-04-01
+
+### Added
+
+- Older release.
+`, releaseDate, body)
+}
+
+func writeFile(t *testing.T, dir string, name string, content string) {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	err := os.WriteFile(path, []byte(content), 0o600)
+	if err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func removeFile(t *testing.T, dir string, name string) {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	err := os.Remove(path)
+	if err != nil {
+		t.Fatalf("remove %s: %v", name, err)
+	}
+}
+
+func runCommand(t *testing.T, dir string, name string, args ...string) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), scriptTimeout)
+	defer cancel()
+
+	command := exec.CommandContext(ctx, name, args...)
+	command.Dir = dir
+
+	output, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("%s timed out: %v", name, ctx.Err())
+	}
+	if err != nil {
+		t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, output)
+	}
+
+	return string(output)
+}

--- a/scripts/ci/prepare_github_release_test.go
+++ b/scripts/ci/prepare_github_release_test.go
@@ -37,7 +37,6 @@ const (
 	releaseVersion     = "1.1.0"
 	releaseModeEnv     = "RELEASE_MODE"
 	releaseNotesCommit = "docs: prepare release notes"
-	releasePRLabelsEnv = "RELEASE_PR_LABELS"
 	releasePRTitleEnv  = "RELEASE_PR_TITLE"
 	scriptTimeout      = 15 * time.Second
 	seedCommitMessage  = "docs: seed changelog"
@@ -111,23 +110,6 @@ func TestPrepareGitHubReleaseValidatesReleasePRTitle(t *testing.T) {
 	requireOutputValue(t, output.tag, releaseTag, outputTag)
 	requireOutputValue(t, output.date, releaseDate, outputDate)
 	requireOutputValue(t, output.tagExists, outputFalse, outputTagExists)
-	requireReleaseBody(t, output.bodyFile, releaseBody)
-}
-
-func TestPrepareGitHubReleaseValidatesReleasePRLabel(t *testing.T) {
-	repo := newReleaseRepo(t)
-
-	repo.writeChangelog(t, changelogWithTopRelease(releaseVersion, releaseBody))
-	repo.commit(t, releaseNotesCommit)
-
-	output := repo.requirePrepareSuccess(
-		t,
-		envAssignment(releaseModeEnv, modeValidatePR),
-		envAssignment(releasePRLabelsEnv, "documentation,release"),
-	)
-
-	requireOutputValue(t, output.releaseDetected, outputTrue, outputRelease)
-	requireOutputValue(t, output.tag, releaseTag, outputTag)
 	requireReleaseBody(t, output.bodyFile, releaseBody)
 }
 


### PR DESCRIPTION
## Summary

- Add PR-time release validation to the release workflow
- Detect release PRs from `release: vX.Y.Z` titles, the `release` label, or a new top changelog release entry
- Fail release PRs early when the version is malformed, inconsistent with the changelog, missing a release body, or already tagged
- Keep tag creation and GitHub release publishing on the post-merge `push` to `main`
- Gracefully skip ordinary PRs and ordinary pushes

Resolves: #49 