### PR TITLE
fix(validation): cache repo validation failures and allowlist config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on Keep a Changelog, with the current development state trac
 - Added an automated release workflow that validates release-prep pull requests, tags the final `main` commit after merge, and publishes the GitHub release from the curated changelog body. (@TobyTheHutt)
 - Added GitHub generated release-note configuration and label guidance without replacing the curated changelog. (@TobyTheHutt)
 
+### Fixed
+
+- Cached analyzer repo-wide validation failures, parsed allowlists, and normalized validation config per process so repeated stale-selector analyzer passes fail closed without recomputing the same repo-wide state. (@TobyTheHutt)
+
 ## [2.0.2] - 2026-03-22
 
 ### Fixed

--- a/internal/validation/analyzer.go
+++ b/internal/validation/analyzer.go
@@ -59,12 +59,7 @@ type analyzerConfig struct {
 	allowlistPath      string
 	roots              string
 	repoRoot           string
-	loadRepoValidation func(
-		repoRoot string,
-		roots []string,
-		allowlist AnyAllowlist,
-		allowlistFingerprint string,
-	) (repoValidationResult, error)
+	loadRepoValidation func(repoValidationConfig) (repoValidationResult, error)
 }
 
 type analyzerFile struct {
@@ -96,13 +91,19 @@ func (cfg *analyzerConfig) run(pass *analysis.Pass) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	loadedAllowlist, err := loadAnyAllowlist(allowlistPath)
+
+	buildCtx := currentBuildContext()
+	validationConfig, err := loadRepoValidationConfig(repoRoot, roots, allowlistPath, buildCtx)
 	if err != nil {
 		return nil, err
 	}
-	allowlist := loadedAllowlist.allowlist
 
-	files, err := collectAnalyzerFiles(pass, repoRoot, roots, allowlist.ExcludeGlobs)
+	files, err := collectAnalyzerFilesWithNormalizedRoots(
+		pass,
+		repoRoot,
+		validationConfig.roots,
+		validationConfig.allowlist.ExcludeGlobs,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +114,7 @@ func (cfg *analyzerConfig) run(pass *analysis.Pass) (any, error) {
 
 	// collectAnalyzerFindings builds packageFindings for current-package diagnostics,
 	// while repo-wide validation is cached across analyzer passes in the same process.
-	repoResult, err := cfg.loadRepoValidationResult(repoRoot, roots, allowlist, loadedAllowlist.fingerprint)
+	repoResult, err := cfg.loadRepoValidationResult(validationConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -122,16 +123,11 @@ func (cfg *analyzerConfig) run(pass *analysis.Pass) (any, error) {
 	return analysisResult{}, nil
 }
 
-func (cfg *analyzerConfig) loadRepoValidationResult(
-	repoRoot string,
-	roots []string,
-	allowlist AnyAllowlist,
-	allowlistFingerprint string,
-) (repoValidationResult, error) {
+func (cfg *analyzerConfig) loadRepoValidationResult(config repoValidationConfig) (repoValidationResult, error) {
 	if cfg.loadRepoValidation != nil {
-		return cfg.loadRepoValidation(repoRoot, roots, allowlist, allowlistFingerprint)
+		return cfg.loadRepoValidation(config)
 	}
-	return loadRepoValidationResult(repoRoot, roots, allowlist, allowlistFingerprint)
+	return loadRepoValidationResult(config)
 }
 
 func (cfg *analyzerConfig) resolveRepoRoot(pass *analysis.Pass) (string, error) {
@@ -200,6 +196,15 @@ func resolveAllowlistPath(repoRoot, configured string) (string, error) {
 
 func collectAnalyzerFiles(pass *analysis.Pass, repoRoot string, roots []string, excludeGlobs []string) ([]analyzerFile, error) {
 	filteredRoots := normalizeConfiguredRoots(roots, repoRoot)
+	return collectAnalyzerFilesWithNormalizedRoots(pass, repoRoot, filteredRoots, excludeGlobs)
+}
+
+func collectAnalyzerFilesWithNormalizedRoots(
+	pass *analysis.Pass,
+	repoRoot string,
+	filteredRoots []string,
+	excludeGlobs []string,
+) ([]analyzerFile, error) {
 	if len(filteredRoots) == 0 {
 		return nil, errors.New("no usable roots after normalization")
 	}

--- a/internal/validation/execution_model_test.go
+++ b/internal/validation/execution_model_test.go
@@ -83,23 +83,15 @@ func TestAnalyzerRunReportsPackageLocalDiagnosticsAndReusesRepoValidation(t *tes
 	cfg := testSyntheticAnalyzerConfig(fixture)
 	var cache repoValidationCache
 	repoValidationCalls := 0
-	cfg.loadRepoValidation = func(
-		repoRoot string,
-		roots []string,
-		allowlist AnyAllowlist,
-		allowlistFingerprint string,
-	) (repoValidationResult, error) {
-		buildCtx := currentBuildContext()
-		key := newRepoValidationCacheKey(
-			repoRoot,
-			roots,
-			allowlistFingerprint,
-			allowlist.ExcludeGlobs,
-			buildContextCacheKey(buildCtx),
-		)
-		return cache.load(key, func() (repoValidationResult, error) {
+	cfg.loadRepoValidation = func(config repoValidationConfig) (repoValidationResult, error) {
+		return cache.load(config.cacheKey, func() (repoValidationResult, error) {
 			repoValidationCalls++
-			return collectRepoValidationResultWithBuildContext(repoRoot, roots, allowlist, buildCtx)
+			return collectRepoValidationResultWithBuildContext(
+				config.repoRoot,
+				config.roots,
+				config.allowlist,
+				config.buildCtx,
+			)
 		})
 	}
 

--- a/internal/validation/repo_validation_cache.go
+++ b/internal/validation/repo_validation_cache.go
@@ -1,9 +1,9 @@
 package validation
 
 import (
-	"errors"
 	"go/build"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -15,6 +15,24 @@ type repoValidationResult struct {
 	index anyAllowlistIndex
 }
 
+// repoValidationConfig freezes analyzer-wide inputs that are identical across
+// package passes. cacheKey carries the allowlist fingerprint used for exact
+// repo validation result reuse.
+type repoValidationConfig struct {
+	allowlist AnyAllowlist
+	buildCtx  *build.Context
+	cacheKey  repoValidationCacheKey
+	repoRoot  string
+	roots     []string
+}
+
+type repoValidationConfigCacheKey struct {
+	allowlistPath string
+	build         string
+	repoRoot      string
+	roots         string
+}
+
 type repoValidationCacheKey struct {
 	repoRoot    string
 	roots       string
@@ -23,9 +41,32 @@ type repoValidationCacheKey struct {
 	build       string
 }
 
+type anyAllowlistCacheKey struct {
+	path string
+}
+
+type anyAllowlistCache struct {
+	cache processCache[anyAllowlistCacheKey, loadedAnyAllowlist]
+}
+
+type repoValidationConfigCache struct {
+	cache processCache[repoValidationConfigCacheKey, repoValidationConfig]
+}
+
 type repoValidationCache struct {
+	cache processCache[repoValidationCacheKey, repoValidationResult]
+}
+
+type processCache[K comparable, V any] struct {
 	entries sync.Map
 	group   singleflight.Group
+}
+
+// processCacheEntry stores failures intentionally. Stale allowlist selectors
+// should fail closed once, then return the same error on later package passes.
+type processCacheEntry[V any] struct {
+	value V
+	err   error
 }
 
 // processRepoValidationCache is intentionally append-only for the lifetime of a
@@ -34,24 +75,73 @@ type repoValidationCache struct {
 // eviction would increase hot-path synchronization without a practical benefit.
 var processRepoValidationCache repoValidationCache
 
+var processRepoValidationConfigCache repoValidationConfigCache
+
+var processAnyAllowlistCache anyAllowlistCache
+
 var repoValidationResultCollector = collectRepoValidationResultWithBuildContext
 
-func loadRepoValidationResult(
+var repoValidationAllowlistLoader = loadAnyAllowlist
+
+func loadRepoValidationConfig(
 	repoRoot string,
 	roots []string,
-	allowlist AnyAllowlist,
-	allowlistFingerprint string,
-) (repoValidationResult, error) {
-	buildCtx := currentBuildContext()
-	key := newRepoValidationCacheKey(
-		repoRoot,
-		roots,
-		allowlistFingerprint,
-		allowlist.ExcludeGlobs,
-		buildContextCacheKey(buildCtx),
+	allowlistPath string,
+	buildCtx *build.Context,
+) (repoValidationConfig, error) {
+	if buildCtx == nil {
+		buildCtx = currentBuildContext()
+	}
+
+	buildKey := buildContextCacheKey(buildCtx)
+	key := newRepoValidationConfigCacheKey(repoRoot, roots, allowlistPath, buildKey)
+
+	return processRepoValidationConfigCache.load(key, func() (repoValidationConfig, error) {
+		return collectRepoValidationConfig(key, roots, buildCtx)
+	})
+}
+
+func collectRepoValidationConfig(
+	key repoValidationConfigCacheKey,
+	roots []string,
+	buildCtx *build.Context,
+) (repoValidationConfig, error) {
+	loaded, err := loadProcessCachedAnyAllowlist(key.allowlistPath)
+	if err != nil {
+		return repoValidationConfig{}, err
+	}
+
+	normalizedRoots := normalizeConfiguredRoots(roots, key.repoRoot)
+	normalizedGlobs := normalizeRepoValidationCacheGlobs(loaded.allowlist.ExcludeGlobs)
+	allowlist := loaded.allowlist
+	allowlist.ExcludeGlobs = cloneStrings(normalizedGlobs)
+
+	cacheKey := newNormalizedRepoValidationCacheKey(
+		key.repoRoot,
+		normalizedRoots,
+		loaded.fingerprint,
+		normalizedGlobs,
+		key.build,
 	)
-	return processRepoValidationCache.load(key, func() (repoValidationResult, error) {
-		return repoValidationResultCollector(repoRoot, roots, allowlist, buildCtx)
+	return repoValidationConfig{
+		allowlist: allowlist,
+		buildCtx:  cloneBuildContext(buildCtx),
+		cacheKey:  cacheKey,
+		repoRoot:  key.repoRoot,
+		roots:     cloneStrings(normalizedRoots),
+	}, nil
+}
+
+func loadProcessCachedAnyAllowlist(listPath string) (loadedAnyAllowlist, error) {
+	key := newAnyAllowlistCacheKey(listPath)
+	return processAnyAllowlistCache.load(key, func() (loadedAnyAllowlist, error) {
+		return repoValidationAllowlistLoader(key.path)
+	})
+}
+
+func loadRepoValidationResult(config repoValidationConfig) (repoValidationResult, error) {
+	return processRepoValidationCache.load(config.cacheKey, func() (repoValidationResult, error) {
+		return repoValidationResultCollector(config.repoRoot, config.roots, config.allowlist, config.buildCtx)
 	})
 }
 
@@ -83,17 +173,57 @@ func newRepoValidationCacheKey(
 ) repoValidationCacheKey {
 	cleanRepoRoot := filepath.Clean(repoRoot)
 	normalizedRoots := normalizeConfiguredRoots(roots, cleanRepoRoot)
-	sort.Strings(normalizedRoots)
-
 	normalizedGlobs := normalizeRepoValidationCacheGlobs(excludeGlobs)
-	sort.Strings(normalizedGlobs)
+	return newNormalizedRepoValidationCacheKey(
+		cleanRepoRoot,
+		normalizedRoots,
+		allowlistFingerprint,
+		normalizedGlobs,
+		buildKey,
+	)
+}
+
+// newNormalizedRepoValidationCacheKey expects caller-normalized inputs. The
+// analyzer path produces them in collectRepoValidationConfig before caching.
+func newNormalizedRepoValidationCacheKey(
+	repoRoot string,
+	normalizedRoots []string,
+	allowlistFingerprint string,
+	normalizedGlobs []string,
+	buildKey string,
+) repoValidationCacheKey {
+	rootKeyParts := cloneStrings(normalizedRoots)
+	sort.Strings(rootKeyParts)
+
+	globKeyParts := cloneStrings(normalizedGlobs)
+	sort.Strings(globKeyParts)
 
 	return repoValidationCacheKey{
-		repoRoot:    filepath.ToSlash(cleanRepoRoot),
-		roots:       strings.Join(normalizedRoots, "\n"),
+		repoRoot:    filepath.ToSlash(repoRoot),
+		roots:       strings.Join(rootKeyParts, "\n"),
 		allowlistID: strings.TrimSpace(allowlistFingerprint),
-		exclude:     strings.Join(normalizedGlobs, "\n"),
+		exclude:     strings.Join(globKeyParts, "\n"),
 		build:       strings.TrimSpace(buildKey),
+	}
+}
+
+func newRepoValidationConfigCacheKey(
+	repoRoot string,
+	roots []string,
+	allowlistPath string,
+	buildKey string,
+) repoValidationConfigCacheKey {
+	return repoValidationConfigCacheKey{
+		allowlistPath: filepath.Clean(allowlistPath),
+		build:         strings.TrimSpace(buildKey),
+		repoRoot:      filepath.Clean(repoRoot),
+		roots:         strings.Join(roots, "\n"),
+	}
+}
+
+func newAnyAllowlistCacheKey(listPath string) anyAllowlistCacheKey {
+	return anyAllowlistCacheKey{
+		path: filepath.Clean(listPath),
 	}
 }
 
@@ -109,39 +239,96 @@ func normalizeRepoValidationCacheGlobs(globs []string) []string {
 	return normalized
 }
 
+func cloneBuildContext(buildCtx *build.Context) *build.Context {
+	if buildCtx == nil {
+		return currentBuildContext()
+	}
+
+	cloned := *buildCtx
+	cloned.BuildTags = cloneStrings(buildCtx.BuildTags)
+	cloned.ToolTags = cloneStrings(buildCtx.ToolTags)
+	cloned.ReleaseTags = cloneStrings(buildCtx.ReleaseTags)
+	return &cloned
+}
+
+func cloneStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	return append([]string(nil), values...)
+}
+
+func (cache *anyAllowlistCache) load(
+	key anyAllowlistCacheKey,
+	collect func() (loadedAnyAllowlist, error),
+) (loadedAnyAllowlist, error) {
+	return cache.cache.load(key, key.singleflightKey(), collect, "unexpected any allowlist cache value type")
+}
+
+func (key anyAllowlistCacheKey) singleflightKey() string {
+	return key.path
+}
+
+func (cache *repoValidationConfigCache) load(
+	key repoValidationConfigCacheKey,
+	collect func() (repoValidationConfig, error),
+) (repoValidationConfig, error) {
+	return cache.cache.load(key, key.singleflightKey(), collect, "unexpected repo validation config cache value type")
+}
+
+func (key repoValidationConfigCacheKey) singleflightKey() string {
+	return strings.Join([]string{key.repoRoot, key.roots, key.allowlistPath, key.build}, "\x00")
+}
+
 func (cache *repoValidationCache) load(
 	key repoValidationCacheKey,
 	collect func() (repoValidationResult, error),
 ) (repoValidationResult, error) {
+	return cache.cache.load(key, key.singleflightKey(), collect, "unexpected repo validation cache value type")
+}
+
+func (cache *processCache[K, V]) load(
+	key K,
+	singleflightKey string,
+	collect func() (V, error),
+	typeErr string,
+) (V, error) {
 	if cached, found := cache.entries.Load(key); found {
-		cachedResult, ok := cached.(repoValidationResult)
-		if ok {
-			return cachedResult, nil
-		}
+		return unpackProcessCacheEntry[V](cached, typeErr)
 	}
 
-	value, err, _ := cache.group.Do(key.singleflightKey(), func() (any, error) {
-		if cached, ok := cache.entries.Load(key); ok {
+	value, err, _ := cache.group.Do(singleflightKey, func() (interface{}, error) {
+		if cached, found := cache.entries.Load(key); found {
 			return cached, nil
 		}
 
-		result, collectErr := collect()
-		if collectErr != nil {
-			return repoValidationResult{}, collectErr
+		result, resultErr := collect()
+		entry := processCacheEntry[V]{
+			value: result,
+			err:   resultErr,
 		}
-
-		cache.entries.Store(key, result)
-		return result, nil
+		cache.entries.Store(key, entry)
+		return entry, nil
 	})
 	if err != nil {
-		return repoValidationResult{}, err
+		var zero V
+		return zero, err
 	}
 
-	result, ok := value.(repoValidationResult)
+	return unpackProcessCacheEntry[V](value, typeErr)
+}
+
+func unpackProcessCacheEntry[V any](value interface{}, typeErr string) (V, error) {
+	entry, ok := value.(processCacheEntry[V])
 	if ok {
-		return result, nil
+		return entry.value, entry.err
 	}
-	return repoValidationResult{}, errors.New("unexpected repo validation cache value type")
+
+	valueType := reflect.TypeOf(value)
+	if valueType == nil {
+		panic(typeErr + ": got <nil>")
+	}
+	panic(typeErr + ": got " + valueType.String())
 }
 
 func (key repoValidationCacheKey) singleflightKey() string {
@@ -150,4 +337,6 @@ func (key repoValidationCacheKey) singleflightKey() string {
 
 func resetProcessRepoValidationCacheForTesting() {
 	processRepoValidationCache = repoValidationCache{}
+	processRepoValidationConfigCache = repoValidationConfigCache{}
+	processAnyAllowlistCache = anyAllowlistCache{}
 }

--- a/internal/validation/repo_validation_cache_test.go
+++ b/internal/validation/repo_validation_cache_test.go
@@ -1,9 +1,12 @@
 package validation
 
 import (
+	"errors"
 	"go/build"
+	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -17,6 +20,9 @@ const (
 	testCacheRepoName     = "repo"
 	testCacheFingerprintA = "fingerprint-a"
 	testCacheFingerprintB = "fingerprint-b"
+	testProcessCacheKey   = "wrong-type"
+
+	errExpectedRepresentativeSnapshot = "expected one representative snapshot, got %d"
 )
 
 func TestNewRepoValidationCacheKeyNormalizesInputs(t *testing.T) {
@@ -119,6 +125,125 @@ func TestRepoValidationCacheReusesNormalizedKey(t *testing.T) {
 	}
 }
 
+func TestRepoValidationCacheReusesFailures(t *testing.T) {
+	var cache repoValidationCache
+	key := newRepoValidationCacheKey(
+		filepath.Join(t.TempDir(), testCacheRepoName),
+		[]string{DefaultRoots},
+		testCacheFingerprintA,
+		[]string{"**/*_test.go"},
+		buildContextCacheKey(testBuildContext(testGOOSLinux, testGOARCHAMD64, testBuildTagCustom)),
+	)
+
+	wantErr := errors.New("stale allowlist selector")
+	var calls atomic.Int64
+	collect := func() (repoValidationResult, error) {
+		calls.Add(1)
+		return repoValidationResult{}, wantErr
+	}
+
+	gotA, errA := cache.load(key, collect)
+	gotB, errB := cache.load(key, collect)
+
+	if calls.Load() != 1 {
+		t.Fatalf("expected one failed cache miss, got %d", calls.Load())
+	}
+	if !errors.Is(errA, wantErr) {
+		t.Fatalf("unexpected first cached error: %v", errA)
+	}
+	if !errors.Is(errB, wantErr) {
+		t.Fatalf("unexpected second cached error: %v", errB)
+	}
+	if !reflect.DeepEqual(gotA, repoValidationResult{}) {
+		t.Fatalf("unexpected first failed result: %#v", gotA)
+	}
+	if !reflect.DeepEqual(gotB, repoValidationResult{}) {
+		t.Fatalf("unexpected second failed result: %#v", gotB)
+	}
+}
+
+func TestLoadRepoValidationConfigNormalizesInputs(t *testing.T) {
+	resetProcessRepoValidationCacheForTesting()
+	t.Cleanup(resetProcessRepoValidationCacheForTesting)
+
+	repoRoot := t.TempDir()
+	allowlistPath := filepath.Join(repoRoot, testAllowlistFile)
+	writeRawAllowlist(t, allowlistPath, strings.Join([]string{
+		"version: 2",
+		"exclude_globs:",
+		"  - \" \"",
+		"  - \"./pkg//*.go\"",
+		"entries: []",
+		"",
+	}, "\n"))
+
+	config, err := loadRepoValidationConfig(repoRoot, []string{DefaultRoots}, allowlistPath, nil)
+	if err != nil {
+		t.Fatalf("load repo validation config: %v", err)
+	}
+	if config.buildCtx == nil {
+		t.Fatalf("expected cached build context")
+	}
+	if config.cacheKey.build == "" {
+		t.Fatalf("expected cached build fingerprint")
+	}
+	if !reflect.DeepEqual(config.roots, []string{"."}) {
+		t.Fatalf("unexpected normalized roots: %#v", config.roots)
+	}
+	if !reflect.DeepEqual(config.allowlist.ExcludeGlobs, []string{"pkg/*.go"}) {
+		t.Fatalf("unexpected normalized exclude globs: %#v", config.allowlist.ExcludeGlobs)
+	}
+}
+
+func TestLoadRepoValidationConfigCachesAllowlistFailures(t *testing.T) {
+	resetProcessRepoValidationCacheForTesting()
+	t.Cleanup(resetProcessRepoValidationCacheForTesting)
+
+	repoRoot := t.TempDir()
+	allowlistPath := filepath.Join(repoRoot, testAllowlistFile)
+	originalLoader := repoValidationAllowlistLoader
+	var allowlistLoads atomic.Int64
+	repoValidationAllowlistLoader = func(listPath string) (loadedAnyAllowlist, error) {
+		allowlistLoads.Add(1)
+		return originalLoader(listPath)
+	}
+	t.Cleanup(func() {
+		repoValidationAllowlistLoader = originalLoader
+	})
+
+	for i := 0; i < 2; i++ {
+		_, err := loadRepoValidationConfig(repoRoot, []string{DefaultRoots}, allowlistPath, currentBuildContext())
+		if err == nil {
+			t.Fatalf("expected missing allowlist error on load %d", i+1)
+		}
+	}
+	if allowlistLoads.Load() != 1 {
+		t.Fatalf("expected one cached allowlist load failure, got %d", allowlistLoads.Load())
+	}
+}
+
+func TestProcessCachePanicsOnUnexpectedValueType(t *testing.T) {
+	var cache processCache[string, int]
+	cache.entries.Store(testProcessCacheKey, "cached string")
+
+	expectPanicContains(t, "unexpected test cache value type: got string", func() {
+		result, err := cache.load(testProcessCacheKey, testProcessCacheKey, func() (int, error) {
+			return 1, nil
+		}, "unexpected test cache value type")
+		if err != nil {
+			t.Fatalf("unexpected cache error before panic: %v", err)
+		}
+		_ = result
+	})
+	expectPanicContains(t, "unexpected nil cache value type: got <nil>", func() {
+		result, err := unpackProcessCacheEntry[int](nil, "unexpected nil cache value type")
+		if err != nil {
+			t.Fatalf("unexpected unpack error before panic: %v", err)
+		}
+		_ = result
+	})
+}
+
 func TestRepoValidationCacheConcurrentAccessCollapsesMisses(t *testing.T) {
 	var cache repoValidationCache
 	key := newRepoValidationCacheKey(
@@ -183,6 +308,75 @@ func TestRepoValidationCacheConcurrentAccessCollapsesMisses(t *testing.T) {
 	}
 }
 
+func TestAnalyzerRunReusesRepoValidationFailureAcrossPasses(t *testing.T) {
+	resetProcessRepoValidationCacheForTesting()
+	t.Cleanup(resetProcessRepoValidationCacheForTesting)
+
+	fixture := benchtest.CreateSyntheticRepo(t, benchtest.SyntheticRepoConfig{
+		PackageCount: 4,
+		SafeFiles:    1,
+		UsageFiles:   1,
+	})
+	writeStaleAllowlist(t, fixture.AllowlistPath)
+
+	snapshots := benchtest.LoadPackageSnapshots(t, fixture.Root, []string{fixture.RepresentativePackage})
+	if len(snapshots) != 1 {
+		t.Fatalf(errExpectedRepresentativeSnapshot, len(snapshots))
+	}
+
+	cfg := &analyzerConfig{
+		allowlistPath: fixture.AllowlistRelPath,
+		repoRoot:      fixture.Root,
+		roots:         DefaultRoots,
+	}
+
+	originalLoader := repoValidationAllowlistLoader
+	var allowlistLoads atomic.Int64
+	repoValidationAllowlistLoader = func(listPath string) (loadedAnyAllowlist, error) {
+		allowlistLoads.Add(1)
+		return originalLoader(listPath)
+	}
+	t.Cleanup(func() {
+		repoValidationAllowlistLoader = originalLoader
+	})
+
+	originalCollector := repoValidationResultCollector
+	var repoValidationCalls atomic.Int64
+	repoValidationResultCollector = func(
+		repoRoot string,
+		roots []string,
+		allowlist AnyAllowlist,
+		buildCtx *build.Context,
+	) (repoValidationResult, error) {
+		repoValidationCalls.Add(1)
+		return originalCollector(repoRoot, roots, allowlist, buildCtx)
+	}
+	t.Cleanup(func() {
+		repoValidationResultCollector = originalCollector
+	})
+
+	snapshot := snapshots[0]
+	errorMessages := make([]string, 0, 2)
+	for i := 0; i < 2; i++ {
+		pass := benchtest.NewPass(snapshot, NewAnalyzer(), nil)
+		_, err := cfg.run(pass)
+		if err == nil {
+			t.Fatalf("expected stale-selector error on analyzer pass %d", i+1)
+		}
+		errorMessages = append(errorMessages, err.Error())
+	}
+
+	if allowlistLoads.Load() != 1 {
+		t.Fatalf("expected one allowlist load across failing passes, got %d", allowlistLoads.Load())
+	}
+	if repoValidationCalls.Load() != 1 {
+		t.Fatalf("expected one failed repo-wide validation across repeated passes, got %d", repoValidationCalls.Load())
+	}
+	if errorMessages[0] != errorMessages[1] {
+		t.Fatalf("expected stable cached errors, got %#v", errorMessages)
+	}
+}
+
 func TestAnalyzerRunReusesRepoValidationCacheAcrossPasses(t *testing.T) {
 	resetProcessRepoValidationCacheForTesting()
 	t.Cleanup(resetProcessRepoValidationCacheForTesting)
@@ -194,7 +388,7 @@ func TestAnalyzerRunReusesRepoValidationCacheAcrossPasses(t *testing.T) {
 	})
 	snapshots := benchtest.LoadPackageSnapshots(t, fixture.Root, []string{fixture.RepresentativePackage})
 	if len(snapshots) != 1 {
-		t.Fatalf("expected one representative snapshot, got %d", len(snapshots))
+		t.Fatalf(errExpectedRepresentativeSnapshot, len(snapshots))
 	}
 
 	cfg := &analyzerConfig{
@@ -241,4 +435,58 @@ func TestAnalyzerRunReusesRepoValidationCacheAcrossPasses(t *testing.T) {
 	if diagnosticCounts[0] != diagnosticCounts[1] {
 		t.Fatalf("expected stable repeated analyzer diagnostics, got %#v", diagnosticCounts)
 	}
+}
+
+func writeStaleAllowlist(t *testing.T, path string) {
+	t.Helper()
+
+	lines := []string{
+		"version: 2",
+		"exclude_globs:",
+		"  - \"**/*_test.go\"",
+		"entries:",
+		"  - selector:",
+		"      path: \"pkg/missing.go\"",
+		"      owner: \"Missing\"",
+		"      category: \"*ast.MapType.Value\"",
+		"      line: 1",
+		"      column: 1",
+		"    description: stale selector",
+		"",
+	}
+	content := strings.Join(lines, "\n")
+	err := os.WriteFile(path, []byte(content), 0o600)
+	if err != nil {
+		t.Fatalf("write stale allowlist: %v", err)
+	}
+}
+
+func writeRawAllowlist(t *testing.T, path, content string) {
+	t.Helper()
+
+	err := os.WriteFile(path, []byte(content), 0o600)
+	if err != nil {
+		t.Fatalf("write allowlist: %v", err)
+	}
+}
+
+func expectPanicContains(t *testing.T, want string, run func()) {
+	t.Helper()
+
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Fatalf("expected panic containing %q", want)
+		}
+
+		message, ok := recovered.(string)
+		if !ok {
+			t.Fatalf("expected string panic, got %#v", recovered)
+		}
+		if !strings.Contains(message, want) {
+			t.Fatalf("unexpected panic: got %q want substring %q", message, want)
+		}
+	}()
+
+	run()
 }


### PR DESCRIPTION
## Summary
- cache analyzer repo-validation config, including parsed allowlist data, normalized roots, normalized exclude globs, and build context
- memoize repo-wide validation failures as well as successes
- add focused regression tests for repeated stale-selector failures and cached allowlist/config behavior

Resolves: #65 
