### PR TITLE
perf(validation): precompile exclude glob matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on Keep a Changelog, with the current development state trac
 
 - Added an automated release workflow that validates release-prep pull requests, tags the final `main` commit after merge, and publishes the GitHub release from the curated changelog body. (@TobyTheHutt)
 - Added GitHub generated release-note configuration and label guidance without replacing the curated changelog. (@TobyTheHutt)
+- Added exclude-glob microbenchmarks that compare the previous per-file regex compilation path with reused compiled matchers. (@TobyTheHutt)
+
+### Changed
+
+- Precompiled `exclude_globs` once per allowlist/config load and reused the compiled matchers during file filtering, preserving existing `*`, `**`, and `?` matching semantics while removing regex compilation from the hot path. (@TobyTheHutt)
 
 ### Fixed
 

--- a/internal/validation/analyzer.go
+++ b/internal/validation/analyzer.go
@@ -102,7 +102,7 @@ func (cfg *analyzerConfig) run(pass *analysis.Pass) (any, error) {
 		pass,
 		repoRoot,
 		validationConfig.roots,
-		validationConfig.allowlist.ExcludeGlobs,
+		validationConfig.excludeGlobs,
 	)
 	if err != nil {
 		return nil, err
@@ -196,14 +196,18 @@ func resolveAllowlistPath(repoRoot, configured string) (string, error) {
 
 func collectAnalyzerFiles(pass *analysis.Pass, repoRoot string, roots []string, excludeGlobs []string) ([]analyzerFile, error) {
 	filteredRoots := normalizeConfiguredRoots(roots, repoRoot)
-	return collectAnalyzerFilesWithNormalizedRoots(pass, repoRoot, filteredRoots, excludeGlobs)
+	compiledGlobs, err := compileExcludeGlobs(excludeGlobs)
+	if err != nil {
+		return nil, err
+	}
+	return collectAnalyzerFilesWithNormalizedRoots(pass, repoRoot, filteredRoots, compiledGlobs)
 }
 
 func collectAnalyzerFilesWithNormalizedRoots(
 	pass *analysis.Pass,
 	repoRoot string,
 	filteredRoots []string,
-	excludeGlobs []string,
+	excludeGlobs compiledExcludeGlobs,
 ) ([]analyzerFile, error) {
 	if len(filteredRoots) == 0 {
 		return nil, errors.New("no usable roots after normalization")
@@ -227,7 +231,7 @@ func collectAnalyzerFile(
 	file *ast.File,
 	repoRoot string,
 	roots []string,
-	excludeGlobs []string,
+	excludeGlobs compiledExcludeGlobs,
 ) (analyzerFile, bool, error) {
 	pos := pass.Fset.PositionFor(file.Package, false)
 	if pos.Filename == "" {
@@ -262,7 +266,7 @@ func collectAnalyzerFile(
 	}, true, nil
 }
 
-func shouldCollectAnalyzerPath(relPath string, roots []string, excludeGlobs []string) bool {
+func shouldCollectAnalyzerPath(relPath string, roots []string, excludeGlobs compiledExcludeGlobs) bool {
 	return isWithinRoots(relPath, roots) && !shouldExclude(relPath, excludeGlobs)
 }
 

--- a/internal/validation/any_usage.go
+++ b/internal/validation/any_usage.go
@@ -105,8 +105,9 @@ type AnyAllowlistEntry struct {
 }
 
 type loadedAnyAllowlist struct {
-	allowlist   AnyAllowlist
-	fingerprint string
+	allowlist    AnyAllowlist
+	excludeGlobs compiledExcludeGlobs
+	fingerprint  string
 }
 
 // LoadAnyAllowlist reads and validates a YAML any-usage allowlist file.
@@ -130,9 +131,15 @@ func loadAnyAllowlist(listPath string) (loadedAnyAllowlist, error) {
 		return loadedAnyAllowlist{}, err
 	}
 
+	excludeGlobs, err := compileExcludeGlobs(allowlist.ExcludeGlobs)
+	if err != nil {
+		return loadedAnyAllowlist{}, err
+	}
+
 	return loadedAnyAllowlist{
-		allowlist:   allowlist,
-		fingerprint: fingerprintAnyAllowlistData(data),
+		allowlist:    allowlist,
+		excludeGlobs: excludeGlobs,
+		fingerprint:  fingerprintAnyAllowlistData(data),
 	}, nil
 }
 
@@ -166,11 +173,11 @@ func wrapAllowlistParseError(err error) error {
 
 // ValidateAnyUsageFromFile loads an allowlist and validates any-usage across roots.
 func ValidateAnyUsageFromFile(listPath, baseDir string, roots []string) ([]Error, error) {
-	allowlist, err := LoadAnyAllowlist(listPath)
+	loaded, err := loadAnyAllowlist(listPath)
 	if err != nil {
 		return nil, err
 	}
-	return ValidateAnyUsage(allowlist, baseDir, roots)
+	return validateAnyUsageWithValidatedAllowlist(loaded.allowlist, loaded.excludeGlobs, baseDir, roots)
 }
 
 // ValidateAnyUsage reports any-type usages not covered by the provided allowlist.
@@ -182,12 +189,30 @@ func ValidateAnyUsage(allowlist AnyAllowlist, baseDir string, roots []string) ([
 		return nil, err
 	}
 
+	excludeGlobs, err := compileExcludeGlobs(allowlist.ExcludeGlobs)
+	if err != nil {
+		return nil, err
+	}
+	return validateAnyUsageWithValidatedAllowlist(allowlist, excludeGlobs, baseDir, roots)
+}
+
+func validateAnyUsageWithValidatedAllowlist(
+	allowlist AnyAllowlist,
+	excludeGlobs compiledExcludeGlobs,
+	baseDir string,
+	roots []string,
+) ([]Error, error) {
+	if len(roots) == 0 {
+		return nil, errors.New(errNoRootsProvided)
+	}
+
 	baseAbs, err := filepath.Abs(baseDir)
 	if err != nil {
 		return nil, fmt.Errorf("resolve base dir: %w", err)
 	}
 
-	findings, err := collectFindings(baseAbs, roots, allowlist.ExcludeGlobs)
+	buildCtx := currentBuildContext()
+	findings, err := collectFindingsWithCompiledExcludeGlobs(baseAbs, roots, excludeGlobs, buildCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -205,6 +230,19 @@ func collectFindings(baseAbs string, roots, globs []string) ([]collectedFinding,
 }
 
 func collectFindingsWithBuildContext(baseAbs string, roots, globs []string, buildCtx *build.Context) ([]collectedFinding, error) {
+	excludeGlobs, err := compileExcludeGlobs(globs)
+	if err != nil {
+		return nil, err
+	}
+	return collectFindingsWithCompiledExcludeGlobs(baseAbs, roots, excludeGlobs, buildCtx)
+}
+
+func collectFindingsWithCompiledExcludeGlobs(
+	baseAbs string,
+	roots []string,
+	excludeGlobs compiledExcludeGlobs,
+	buildCtx *build.Context,
+) ([]collectedFinding, error) {
 	if buildCtx == nil {
 		buildCtx = currentBuildContext()
 	}
@@ -219,7 +257,7 @@ func collectFindingsWithBuildContext(baseAbs string, roots, globs []string, buil
 			continue
 		}
 
-		rootFindings, err := collectRootFindings(rootPath, baseAbs, globs, buildCtx)
+		rootFindings, err := collectRootFindings(rootPath, baseAbs, excludeGlobs, buildCtx)
 		if err != nil {
 			return nil, err
 		}
@@ -229,8 +267,13 @@ func collectFindingsWithBuildContext(baseAbs string, roots, globs []string, buil
 	return findings, nil
 }
 
-func collectRootFindings(rootPath, baseAbs string, globs []string, buildCtx *build.Context) ([]collectedFinding, error) {
-	parsed, err := collectParsedPackages(rootPath, baseAbs, globs, buildCtx)
+func collectRootFindings(
+	rootPath string,
+	baseAbs string,
+	excludeGlobs compiledExcludeGlobs,
+	buildCtx *build.Context,
+) ([]collectedFinding, error) {
+	parsed, err := collectParsedPackages(rootPath, baseAbs, excludeGlobs, buildCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +313,7 @@ type parsedPackage struct {
 
 func collectParsedPackages(
 	rootPath, baseAbs string,
-	globs []string,
+	excludeGlobs compiledExcludeGlobs,
 	buildCtx *build.Context,
 ) (parsedPackageCollection, error) {
 	fset := token.NewFileSet()
@@ -279,7 +322,7 @@ func collectParsedPackages(
 		buildCtx = currentBuildContext()
 	}
 
-	err := walkParsedFiles(rootPath, baseAbs, globs, fset, buildCtx, func(file parsedGoFile) error {
+	err := walkParsedFiles(rootPath, baseAbs, excludeGlobs, fset, buildCtx, func(file parsedGoFile) error {
 		appendParsedPackageFile(grouped, file)
 		return nil
 	})
@@ -292,13 +335,13 @@ func collectParsedPackages(
 
 func walkParsedFiles(
 	rootPath, baseAbs string,
-	globs []string,
+	excludeGlobs compiledExcludeGlobs,
 	fset *token.FileSet,
 	buildCtx *build.Context,
 	visit func(parsedGoFile) error,
 ) error {
 	return filepath.WalkDir(rootPath, func(path string, entry fs.DirEntry, walkErr error) error {
-		parsedFile, keep, err := parseRootFile(fset, path, entry, walkErr, baseAbs, globs, buildCtx)
+		parsedFile, keep, err := parseRootFile(fset, path, entry, walkErr, baseAbs, excludeGlobs, buildCtx)
 		if err != nil {
 			return err
 		}
@@ -356,7 +399,7 @@ func parseRootFile(
 	entry fs.DirEntry,
 	walkErr error,
 	baseAbs string,
-	globs []string,
+	excludeGlobs compiledExcludeGlobs,
 	buildCtx *build.Context,
 ) (parsedGoFile, bool, error) {
 	if walkErr != nil {
@@ -371,7 +414,7 @@ func parseRootFile(
 		return parsedGoFile{}, false, relErr
 	}
 	relPath = normalizePath(relPath)
-	if shouldExclude(relPath, globs) {
+	if shouldExclude(relPath, excludeGlobs) {
 		return parsedGoFile{}, false, nil
 	}
 	keepForBuild, err := buildCtx.MatchFile(filepath.Dir(path), filepath.Base(path))
@@ -1461,13 +1504,45 @@ func receiverTypeName(expr ast.Expr) string {
 	}
 }
 
-func shouldExclude(relPath string, globs []string) bool {
-	for _, glob := range globs {
-		if glob == "" {
+// compiledExcludeGlobs keeps exclude patterns in allowlist order while moving
+// regex compilation out of per-file filtering.
+type compiledExcludeGlobs struct {
+	matchers []compiledGlobMatcher
+}
+
+type compiledGlobMatcher struct {
+	pattern string
+	regex   *regexp.Regexp
+}
+
+// compileExcludeGlobs reports the first compilation failure with its YAML list
+// index so invalid configuration fails closed deterministically.
+func compileExcludeGlobs(globs []string) (compiledExcludeGlobs, error) {
+	matchers := make([]compiledGlobMatcher, 0, len(globs))
+	for i, glob := range globs {
+		normalizedGlob := normalizePath(glob)
+		if normalizedGlob == "" {
 			continue
 		}
-		matched, err := matchGlob(glob, relPath)
-		if err == nil && matched {
+
+		matcher, err := compileGlobMatcher(normalizedGlob)
+		if err != nil {
+			return compiledExcludeGlobs{}, fmt.Errorf("compile exclude_globs[%d]: %w", i, err)
+		}
+
+		matchers = append(matchers, matcher)
+	}
+	return compiledExcludeGlobs{matchers: matchers}, nil
+}
+
+func shouldExclude(relPath string, globs compiledExcludeGlobs) bool {
+	return globs.matches(relPath)
+}
+
+func (globs compiledExcludeGlobs) matches(relPath string) bool {
+	normalizedPath := normalizePath(relPath)
+	for _, matcher := range globs.matchers {
+		if matcher.matchesNormalizedPath(normalizedPath) {
 			return true
 		}
 	}
@@ -1475,19 +1550,40 @@ func shouldExclude(relPath string, globs []string) bool {
 }
 
 func matchGlob(pattern, value string) (bool, error) {
-	pattern = normalizePath(pattern)
-	value = normalizePath(value)
+	matcher, err := compileGlobMatcher(pattern)
+	if err != nil {
+		return false, err
+	}
 
+	normalizedValue := normalizePath(value)
+	return matcher.matchesNormalizedPath(normalizedValue), nil
+}
+
+func compileGlobMatcher(pattern string) (compiledGlobMatcher, error) {
+	normalizedPattern := normalizePath(pattern)
+	expr := globRegexExpression(normalizedPattern)
+	regex, err := regexp.Compile(expr)
+	if err != nil {
+		return compiledGlobMatcher{}, fmt.Errorf("compile glob pattern %q: %w", normalizedPattern, err)
+	}
+	return compiledGlobMatcher{
+		pattern: normalizedPattern,
+		regex:   regex,
+	}, nil
+}
+
+func (matcher compiledGlobMatcher) matchesNormalizedPath(path string) bool {
+	return matcher.regex.MatchString(path)
+}
+
+func globRegexExpression(pattern string) string {
+	// Preserve the historical glob semantics exactly: `*` and `?` stay within a
+	// path segment, while `**` may cross slash boundaries.
 	escaped := regexp.QuoteMeta(pattern)
 	escaped = strings.ReplaceAll(escaped, `\*\*`, anyTokenMarker)
 	escaped = strings.ReplaceAll(escaped, `\*`, `[^/]*`)
 	escaped = strings.ReplaceAll(escaped, `\?`, `[^/]`)
 	escaped = strings.ReplaceAll(escaped, anyTokenMarker, ".*")
 
-	expr := "^" + escaped + "$"
-	re, err := regexp.Compile(expr)
-	if err != nil {
-		return false, err
-	}
-	return re.MatchString(value), nil
+	return "^" + escaped + "$"
 }

--- a/internal/validation/any_usage_test.go
+++ b/internal/validation/any_usage_test.go
@@ -938,15 +938,79 @@ func TestUtilityFunctions(t *testing.T) {
 }
 
 func TestShouldExcludeAndGlobMatch(t *testing.T) {
-	if !shouldExclude(testFooTestPath, []string{"**/*_test.go"}) {
+	excludeGlobs := mustCompileExcludeGlobs(t, []string{"**/*_test.go"})
+	if !shouldExclude(testFooTestPath, excludeGlobs) {
 		t.Fatalf("expected exclude match")
 	}
-	if shouldExclude("pkg/api/foo.go", []string{"**/*_test.go"}) {
+	if shouldExclude("pkg/api/foo.go", excludeGlobs) {
 		t.Fatalf("did not expect exclude match")
 	}
 	ok, err := matchGlob("pkg/**/foo*.go", testFooTestPath)
 	if err != nil || !ok {
 		t.Fatalf("expected recursive glob match, got ok=%v err=%v", ok, err)
+	}
+}
+
+func TestCompiledExcludeGlobsKeepGlobSemantics(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		path    string
+		want    bool
+	}{
+		{
+			name:    "star stays inside path segment",
+			pattern: "pkg/*.go",
+			path:    "pkg/api/foo.go",
+			want:    false,
+		},
+		{
+			name:    "star matches file basename",
+			pattern: "pkg/*.go",
+			path:    "pkg/foo.go",
+			want:    true,
+		},
+		{
+			name:    "double star crosses path segments",
+			pattern: "pkg/**/foo.go",
+			path:    "pkg/api/internal/foo.go",
+			want:    true,
+		},
+		{
+			name:    "question mark stays inside path segment",
+			pattern: "pkg/file?.go",
+			path:    "pkg/file1.go",
+			want:    true,
+		},
+		{
+			name:    "question mark does not cross slash",
+			pattern: "pkg/file?.go",
+			path:    "pkg/file/.go",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			excludeGlobs := mustCompileExcludeGlobs(t, []string{tt.pattern})
+
+			got := shouldExclude(tt.path, excludeGlobs)
+			if got != tt.want {
+				t.Fatalf("unexpected exclude match: got %v want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompileExcludeGlobsNormalizesPatterns(t *testing.T) {
+	excludeGlobs := mustCompileExcludeGlobs(t, []string{" ", "./pkg//*.go"})
+	if got, want := len(excludeGlobs.matchers), 1; got != want {
+		t.Fatalf("unexpected compiled glob count: got %d want %d", got, want)
+	}
+
+	matcher := excludeGlobs.matchers[0]
+	if got, want := matcher.pattern, "pkg/*.go"; got != want {
+		t.Fatalf("unexpected normalized glob pattern: got %q want %q", got, want)
 	}
 }
 
@@ -1590,7 +1654,7 @@ func TestCollectParsedPackagesGroupsByDirectoryAndPackage(t *testing.T) {
 	writeFile(t, filepath.Join(base, testZPath), testPackageAPISource)
 	writeFile(t, filepath.Join(base, testExternalTestPath), "package api_test\n")
 
-	parsed, err := collectParsedPackages(filepath.Join(base, "pkg"), base, nil, nil)
+	parsed, err := collectParsedPackages(filepath.Join(base, "pkg"), base, compiledExcludeGlobs{}, nil)
 	if err != nil {
 		t.Fatalf("collect parsed packages: %v", err)
 	}
@@ -1623,7 +1687,7 @@ func TestParseRootFileSkipsDirectory(t *testing.T) {
 	fset := token.NewFileSet()
 	entry := dirEntryFromPath(t, base)
 
-	_, keep, err := parseRootFile(fset, base, entry, nil, base, nil, currentBuildContext())
+	_, keep, err := parseRootFile(fset, base, entry, nil, base, compiledExcludeGlobs{}, currentBuildContext())
 	if err != nil {
 		t.Fatalf("parse directory: %v", err)
 	}
@@ -1639,7 +1703,8 @@ func TestParseRootFileSkipsExcludedFile(t *testing.T) {
 	writeFile(t, path, testPackageAPISource)
 	entry := dirEntryFromPath(t, path)
 
-	_, keep, err := parseRootFile(fset, path, entry, nil, base, []string{"**/*_test.go"}, currentBuildContext())
+	excludeGlobs := mustCompileExcludeGlobs(t, []string{"**/*_test.go"})
+	_, keep, err := parseRootFile(fset, path, entry, nil, base, excludeGlobs, currentBuildContext())
 	if err != nil {
 		t.Fatalf("parse excluded file: %v", err)
 	}
@@ -1655,7 +1720,15 @@ func TestParseRootFileSkipsInactiveBuildConstrainedFile(t *testing.T) {
 	writeFile(t, path, testPayloadSource)
 	entry := dirEntryFromPath(t, path)
 
-	_, keep, err := parseRootFile(fset, path, entry, nil, base, nil, testBuildContext("linux", "amd64"))
+	_, keep, err := parseRootFile(
+		fset,
+		path,
+		entry,
+		nil,
+		base,
+		compiledExcludeGlobs{},
+		testBuildContext("linux", "amd64"),
+	)
 	if err != nil {
 		t.Fatalf("parse inactive build-constrained file: %v", err)
 	}
@@ -1671,7 +1744,7 @@ func TestParseRootFileReportsParseErrors(t *testing.T) {
 	writeFile(t, path, testBrokenGoSource)
 	entry := dirEntryFromPath(t, path)
 
-	_, keep, err := parseRootFile(fset, path, entry, nil, base, nil, currentBuildContext())
+	_, keep, err := parseRootFile(fset, path, entry, nil, base, compiledExcludeGlobs{}, currentBuildContext())
 	if err == nil {
 		t.Fatal(testExpectedParseError)
 	}
@@ -1687,7 +1760,7 @@ func TestParseRootFileReturnsParsedGoFile(t *testing.T) {
 	writeFile(t, path, testPayloadSource)
 	entry := dirEntryFromPath(t, path)
 
-	parsed, keep, err := parseRootFile(fset, path, entry, nil, base, nil, currentBuildContext())
+	parsed, keep, err := parseRootFile(fset, path, entry, nil, base, compiledExcludeGlobs{}, currentBuildContext())
 	if err != nil {
 		t.Fatalf(testParseFileErrFmt, err)
 	}
@@ -1846,6 +1919,16 @@ type violationSummary struct {
 	category string
 	line     int
 	column   int
+}
+
+func mustCompileExcludeGlobs(t *testing.T, globs []string) compiledExcludeGlobs {
+	t.Helper()
+
+	excludeGlobs, err := compileExcludeGlobs(globs)
+	if err != nil {
+		t.Fatalf("compile exclude globs: %v", err)
+	}
+	return excludeGlobs
 }
 
 func collectUsageSummaries(t *testing.T, src string) []usageSummary {

--- a/internal/validation/benchmark_test.go
+++ b/internal/validation/benchmark_test.go
@@ -70,6 +70,29 @@ func BenchmarkCollectFindings(b *testing.B) {
 	})
 }
 
+func BenchmarkExcludeGlobMatching(b *testing.B) {
+	globs := benchmarkExcludeGlobs()
+	paths := benchmarkExcludePaths()
+	compiledGlobs, err := compileExcludeGlobs(globs)
+	if err != nil {
+		b.Fatalf("compile benchmark exclude globs: %v", err)
+	}
+
+	b.Run("old-compile-regex-per-path", func(b *testing.B) {
+		b.ReportAllocs()
+		benchmarkExcludeMatchCount = benchmarkExcludeMatching(b, paths, func(path string) bool {
+			return benchmarkShouldExcludeUncompiled(path, globs)
+		})
+	})
+
+	b.Run("new-reuse-compiled-regex", func(b *testing.B) {
+		b.ReportAllocs()
+		benchmarkExcludeMatchCount = benchmarkExcludeMatching(b, paths, func(path string) bool {
+			return shouldExclude(path, compiledGlobs)
+		})
+	})
+}
+
 func BenchmarkResolveAllowlistIndex(b *testing.B) {
 	fixture := benchtest.CreateSyntheticRepo(b, benchtest.DefaultSyntheticRepoConfig())
 	allowlist := benchmarkAllowlist(fixture.Selectors)
@@ -252,4 +275,56 @@ func benchmarkAnalyzerRunReusedResetCache(b *testing.B, cfg *analyzerConfig, sna
 			b.Fatal(errExpectedAnalyzerDiagnostics)
 		}
 	}
+}
+
+var benchmarkExcludeMatchCount int
+
+func benchmarkExcludeGlobs() []string {
+	return []string{
+		"**/*_test.go",
+		"pkg/**/generated?.go",
+		"pkg/**/fixture*.go",
+		"internal/tmp/**",
+		"cmd/*/mock?.go",
+	}
+}
+
+func benchmarkExcludePaths() []string {
+	return []string{
+		"pkg/api/foo.go",
+		"pkg/api/foo_test.go",
+		"pkg/api/internal/generated1.go",
+		"pkg/service/fixture_alpha.go",
+		"internal/tmp/cache/value.go",
+		"cmd/anyguard/mock1.go",
+		"cmd/anyguard/main.go",
+	}
+}
+
+func benchmarkExcludeMatching(b *testing.B, paths []string, match func(string) bool) int {
+	b.Helper()
+
+	matches := 0
+	for i := 0; i < b.N; i++ {
+		pathIndex := i % len(paths)
+		path := paths[pathIndex]
+		if match(path) {
+			matches++
+		}
+	}
+	return matches
+}
+
+func benchmarkShouldExcludeUncompiled(relPath string, globs []string) bool {
+	for _, glob := range globs {
+		if glob == "" {
+			continue
+		}
+
+		matched, err := matchGlob(glob, relPath)
+		if err == nil && matched {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/validation/execution_model_test.go
+++ b/internal/validation/execution_model_test.go
@@ -90,6 +90,7 @@ func TestAnalyzerRunReportsPackageLocalDiagnosticsAndReusesRepoValidation(t *tes
 				config.repoRoot,
 				config.roots,
 				config.allowlist,
+				config.excludeGlobs,
 				config.buildCtx,
 			)
 		})

--- a/internal/validation/repo_validation_cache.go
+++ b/internal/validation/repo_validation_cache.go
@@ -19,11 +19,12 @@ type repoValidationResult struct {
 // package passes. cacheKey carries the allowlist fingerprint used for exact
 // repo validation result reuse.
 type repoValidationConfig struct {
-	allowlist AnyAllowlist
-	buildCtx  *build.Context
-	cacheKey  repoValidationCacheKey
-	repoRoot  string
-	roots     []string
+	allowlist    AnyAllowlist
+	buildCtx     *build.Context
+	cacheKey     repoValidationCacheKey
+	excludeGlobs compiledExcludeGlobs
+	repoRoot     string
+	roots        []string
 }
 
 type repoValidationConfigCacheKey struct {
@@ -124,11 +125,12 @@ func collectRepoValidationConfig(
 		key.build,
 	)
 	return repoValidationConfig{
-		allowlist: allowlist,
-		buildCtx:  cloneBuildContext(buildCtx),
-		cacheKey:  cacheKey,
-		repoRoot:  key.repoRoot,
-		roots:     cloneStrings(normalizedRoots),
+		allowlist:    allowlist,
+		buildCtx:     cloneBuildContext(buildCtx),
+		cacheKey:     cacheKey,
+		excludeGlobs: loaded.excludeGlobs,
+		repoRoot:     key.repoRoot,
+		roots:        cloneStrings(normalizedRoots),
 	}, nil
 }
 
@@ -141,7 +143,13 @@ func loadProcessCachedAnyAllowlist(listPath string) (loadedAnyAllowlist, error) 
 
 func loadRepoValidationResult(config repoValidationConfig) (repoValidationResult, error) {
 	return processRepoValidationCache.load(config.cacheKey, func() (repoValidationResult, error) {
-		return repoValidationResultCollector(config.repoRoot, config.roots, config.allowlist, config.buildCtx)
+		return repoValidationResultCollector(
+			config.repoRoot,
+			config.roots,
+			config.allowlist,
+			config.excludeGlobs,
+			config.buildCtx,
+		)
 	})
 }
 
@@ -149,9 +157,10 @@ func collectRepoValidationResultWithBuildContext(
 	repoRoot string,
 	roots []string,
 	allowlist AnyAllowlist,
+	excludeGlobs compiledExcludeGlobs,
 	buildCtx *build.Context,
 ) (repoValidationResult, error) {
-	findings, err := collectFindingsWithBuildContext(repoRoot, roots, allowlist.ExcludeGlobs, buildCtx)
+	findings, err := collectFindingsWithCompiledExcludeGlobs(repoRoot, roots, excludeGlobs, buildCtx)
 	if err != nil {
 		return repoValidationResult{}, err
 	}

--- a/internal/validation/repo_validation_cache_test.go
+++ b/internal/validation/repo_validation_cache_test.go
@@ -190,8 +190,16 @@ func TestLoadRepoValidationConfigNormalizesInputs(t *testing.T) {
 	if !reflect.DeepEqual(config.roots, []string{"."}) {
 		t.Fatalf("unexpected normalized roots: %#v", config.roots)
 	}
-	if !reflect.DeepEqual(config.allowlist.ExcludeGlobs, []string{"pkg/*.go"}) {
+	const wantExcludeGlob = "pkg/*.go"
+	wantExcludeGlobs := []string{wantExcludeGlob}
+	if !reflect.DeepEqual(config.allowlist.ExcludeGlobs, wantExcludeGlobs) {
 		t.Fatalf("unexpected normalized exclude globs: %#v", config.allowlist.ExcludeGlobs)
+	}
+	if got, want := len(config.excludeGlobs.matchers), 1; got != want {
+		t.Fatalf("unexpected compiled exclude glob count: got %d want %d", got, want)
+	}
+	if got, want := config.excludeGlobs.matchers[0].pattern, wantExcludeGlob; got != want {
+		t.Fatalf("unexpected compiled exclude glob pattern: got %q want %q", got, want)
 	}
 }
 
@@ -346,10 +354,11 @@ func TestAnalyzerRunReusesRepoValidationFailureAcrossPasses(t *testing.T) {
 		repoRoot string,
 		roots []string,
 		allowlist AnyAllowlist,
+		excludeGlobs compiledExcludeGlobs,
 		buildCtx *build.Context,
 	) (repoValidationResult, error) {
 		repoValidationCalls.Add(1)
-		return originalCollector(repoRoot, roots, allowlist, buildCtx)
+		return originalCollector(repoRoot, roots, allowlist, excludeGlobs, buildCtx)
 	}
 	t.Cleanup(func() {
 		repoValidationResultCollector = originalCollector
@@ -403,10 +412,11 @@ func TestAnalyzerRunReusesRepoValidationCacheAcrossPasses(t *testing.T) {
 		repoRoot string,
 		roots []string,
 		allowlist AnyAllowlist,
+		excludeGlobs compiledExcludeGlobs,
 		buildCtx *build.Context,
 	) (repoValidationResult, error) {
 		calls.Add(1)
-		return originalCollector(repoRoot, roots, allowlist, buildCtx)
+		return originalCollector(repoRoot, roots, allowlist, excludeGlobs, buildCtx)
 	}
 	t.Cleanup(func() {
 		repoValidationResultCollector = originalCollector


### PR DESCRIPTION
## Summary
- compile `exclude_globs` once at allowlist/config boundaries
- reuse compiled exclude matchers in repo-wide finding collection and analyzer package-local filtering
- preserve existing `*`, `**`, and `?` glob semantics
- add behavior coverage plus old-vs-new exclude matching microbenchmarks

Resolves: #66 