### PR TITLE
perf(plugin): switch golangci module plugin to syntax load mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on Keep a Changelog, with the current development state trac
 
 - Precompiled `exclude_globs` once per allowlist/config load and reused the compiled matchers during file filtering, preserving existing `*`, `**`, and `?` matching semantics while removing regex compilation from the hot path. (@TobyTheHutt)
 - Switched supported-slot `any` matching from `types.Info` dependence to lexical scope resolution (including shadowing behavior), and aligned analyzer/docs/tests with that contract. (@TobyTheHutt)
+- Switched the golangci-lint module plugin from `typesinfo` to `syntax` load mode after lexical scope resolution removed the `go/types` dependency from supported-slot matching, shadowed-`any` suppression, and repo-wide stale-selector validation. (@TobyTheHutt)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Nested `any` is reportable only when the nested identifier still appears in one 
 - Analyzer/plugin path: the CLI (`cmd/anyguard`), public analyzer (`anyguard.NewAnalyzer()`), and golangci-lint module plugin all run as `go/analysis` frontends. Each pass emits diagnostics only for findings in the package currently under analysis after applying the configured roots and `exclude_globs` to the same canonical repository-relative file identities used by repo-wide allowlist resolution.
 - Repo-wide stale-selector validation still happens on that path. Allowlist resolution is built from repo-wide findings across the configured roots, cached once per process, and reused by later analyzer/plugin passes so stale selectors anywhere under those roots still fail closed.
 - Audit path: the repo-wide validation helper used by this repository's tests and benchmarks walks the configured roots once, applies the active Go build context (`//go:build`, `GOOS`, `GOARCH`, `GOFLAGS=-tags=...`, file suffix constraints, and `CGO_ENABLED`), and returns the full repo violation set in a single call. That is the canonical whole-repo audit path.
-- Performance tradeoff: analyzer/plugin execution avoids rescanning the repo for every package pass, but it still pays one repo-wide allowlist-validation cost and, for analyzer/plugin frontends, per-package `typesinfo` loading. The audit path does one full repo walk and is the reference whole-repo measurement path.
+- Performance tradeoff: analyzer/plugin execution avoids rescanning the repo for every package pass. On the golangci-lint module-plugin path, `anyguard` uses syntax package loading. Supported-slot matching, shadowed-`any` suppression, and repo-wide stale-selector validation read parsed syntax plus lexical scope state rather than `types.Info`. The audit path does one full repo walk and is the reference whole-repo measurement path.
 
 ### Development
 
@@ -227,7 +227,7 @@ The benchmark suite includes `ValidateAnyUsage`, repo-wide finding collection an
 - Stable plugin import path: `github.com/tobythehutt/anyguard/v2/plugin`
 - Plugin name in `.golangci.yml`: `anyguard`
 - Plugin diagnostics follow the same deterministic ordering contract as the CLI and public analyzer.
-- The module plugin requests golangci-lint `typesinfo` load mode for the current release, although supported-slot matching uses lexical scope resolution.
+- The module plugin requests golangci-lint `syntax` load mode. Supported-slot matching, shadowed-`any` suppression, and repo-wide stale-selector validation use parsed syntax plus lexical scope resolution rather than `types.Info`.
 - The module plugin reports diagnostics for the current package only. Repo-wide allowlist and stale-selector validation are shared across the golangci-lint process and are not redone as a whole-repo audit for every package.
 - Integration docs and examples: `docs/golangci-lint/README.md`
 - Upstream readiness notes: `docs/golangci-lint/README.md#upstream-readiness`

--- a/docs/golangci-lint/README.md
+++ b/docs/golangci-lint/README.md
@@ -7,7 +7,7 @@
 - Linter name in `.golangci.yml`: `anyguard`
 - Module-plugin diagnostics follow the same deterministic ordering compatibility guarantee as the CLI and public analyzer.
 - The plugin uses the same AST-slot-driven contract as the CLI and public analyzer.
-- It requests golangci-lint `typesinfo` load mode for the current release, although supported-slot matching uses lexical scope resolution.
+- It requests golangci-lint `syntax` load mode. Supported-slot matching, shadowed-`any` suppression, and repo-wide stale-selector validation use parsed syntax plus lexical scope resolution rather than `types.Info`.
 - It reports `any` in supported AST child slots, and every supported slot uses lexical resolution of the universe `any` alias to suppress shadowed declarations.
 - The detection contract distinguishes dedicated type-position slots from the three compatibility slots, and there are no syntax-only slots left in the implementation.
 
@@ -60,11 +60,11 @@ linters:
 
 ## Load mode and performance
 
-- The module plugin requires `typesinfo` load mode.
-- This increases golangci-lint package loading cost compared with a syntax-only plugin because packages are type checked before `anyguard` runs, although matching does not consume `types.Info`.
+- The module plugin requires `syntax` load mode.
+- This skips golangci-lint package type checking before `anyguard` runs. Matching, shadowed-`any` suppression, and stale-selector validation do not consume `types.Info`.
 - The plugin also pays one repo-wide allowlist-validation cost per golangci-lint process so stale selectors remain fail-closed across the configured roots.
 - It does not run a whole-repo diagnostic audit on every package. Only current-package diagnostics are emitted per pass.
-- Compared with the audit path, the tradeoff is higher per-package `typesinfo` loading but no repeated repo scan for every package.
+- Compared with the audit path, the tradeoff is lower per-package front-end cost but no repeated repo scan for every package.
 - Module-plugin diagnostics stay sorted by `file`, `line`, `column`, `category`, and `owner`, independent of configured root order, filesystem traversal order, and map iteration.
 - Canonical finding identity and exact allowlist matching include `line` and `column` coordinates.
 - Legacy allowlist selectors that omit coordinates are accepted only when `{path, owner, category}` still resolves to exactly one current finding.
@@ -98,6 +98,7 @@ For maintainers evaluating possible core inclusion:
 
 - The normative spec is the root [`Behavior`](../../README.md#behavior), [`Comparison With Generic Ban-Pattern Linters`](../../README.md#comparison-with-generic-ban-pattern-linters), [`Allowlist Schema`](../../README.md#allowlist-schema), and [`Detection Contract`](../../README.md#detection-contract).
 - Supported syntax categories are exactly the AST child slots in the detection contract. Every supported slot uses lexical resolution of the universe `any` alias. The only slots outside dedicated type positions are the three compatibility slots. Anything outside that list is out of scope and intentionally silent.
+- The module plugin uses golangci-lint `syntax` load mode. Supported-slot matching, shadowed-`any` suppression, and repo-wide stale-selector validation run from parsed syntax plus lexical scope state rather than `types.Info`.
 - Each finding has one exact identity: `{path, owner, category, line, column}`. Allowlist matching is exact on that identity.
 - Legacy selectors without `line` and `column` are accepted only when their `{path, owner, category}` triple still resolves to exactly one current finding.
 - Module-plugin execution is package-local for diagnostics, but stale-selector validation remains repo-wide across the configured roots and is reused across package passes in the same process.

--- a/internal/benchtest/benchtest.go
+++ b/internal/benchtest/benchtest.go
@@ -38,12 +38,24 @@ const (
 	selectorsPerBenchmarkFile = 4
 )
 
-const packageLoadMode = packages.NeedName |
+// PackageLoadMode controls how much package metadata bench fixtures load.
+type PackageLoadMode int
+
+const (
+	// PackageLoadModeSyntax loads parsed files.
+	PackageLoadModeSyntax PackageLoadMode = iota
+	// PackageLoadModeTypesInfo adds package type data.
+	PackageLoadModeTypesInfo
+)
+
+const packageLoadModeSyntax = packages.NeedName |
 	packages.NeedFiles |
 	packages.NeedCompiledGoFiles |
 	packages.NeedImports |
 	packages.NeedDeps |
-	packages.NeedSyntax |
+	packages.NeedSyntax
+
+const packageLoadModeTypesInfo = packageLoadModeSyntax |
 	packages.NeedTypes |
 	packages.NeedTypesInfo
 
@@ -193,11 +205,23 @@ func copyModuleTreeEntry(srcRoot, dstRoot, path string, entry os.DirEntry, walkE
 
 func LoadPackageSnapshots(tb testing.TB, dir string, patterns []string) []PackageSnapshot {
 	tb.Helper()
+	defaultLoadMode := PackageLoadModeTypesInfo
+	return LoadPackageSnapshotsWithMode(tb, dir, patterns, defaultLoadMode)
+}
+
+// LoadPackageSnapshotsWithMode loads package snapshots for the requested frontend mode.
+func LoadPackageSnapshotsWithMode(
+	tb testing.TB,
+	dir string,
+	patterns []string,
+	loadMode PackageLoadMode,
+) []PackageSnapshot {
+	tb.Helper()
 
 	cfg := &packages.Config{
 		Dir:  dir,
 		Env:  append(os.Environ(), "GOWORK=off"),
-		Mode: packageLoadMode,
+		Mode: snapshotPackageLoadMode(loadMode),
 	}
 	pkgs, err := packages.Load(cfg, patterns...)
 	if err != nil {
@@ -209,18 +233,8 @@ func LoadPackageSnapshots(tb testing.TB, dir string, patterns []string) []Packag
 
 	snapshots := make([]PackageSnapshot, 0, len(pkgs))
 	for _, pkg := range pkgs {
-		if pkg.Types == nil || pkg.TypesInfo == nil || pkg.Fset == nil || len(pkg.Syntax) == 0 {
-			tb.Fatalf("package %q missing syntax or type information", pkg.PkgPath)
-		}
-
-		snapshots = append(snapshots, PackageSnapshot{
-			Fset:      pkg.Fset,
-			Files:     pkg.Syntax,
-			Path:      pkg.PkgPath,
-			ReadFile:  os.ReadFile,
-			Types:     pkg.Types,
-			TypesInfo: pkg.TypesInfo,
-		})
+		validateSnapshotPackage(tb, pkg, loadMode)
+		snapshots = append(snapshots, newPackageSnapshot(pkg))
 	}
 
 	sort.Slice(snapshots, func(i, j int) bool {
@@ -229,10 +243,55 @@ func LoadPackageSnapshots(tb testing.TB, dir string, patterns []string) []Packag
 	return snapshots
 }
 
+func snapshotPackageLoadMode(loadMode PackageLoadMode) packages.LoadMode {
+	mode := packageLoadModeTypesInfo
+	if loadMode == PackageLoadModeSyntax {
+		mode = packageLoadModeSyntax
+	}
+	return mode
+}
+
+func validateSnapshotPackage(tb testing.TB, pkg *packages.Package, loadMode PackageLoadMode) {
+	tb.Helper()
+
+	hasFileSet := pkg.Fset != nil
+	hasSyntax := len(pkg.Syntax) > 0
+	if !hasFileSet || !hasSyntax {
+		tb.Fatalf("package %q missing syntax information", pkg.PkgPath)
+	}
+	if loadMode != PackageLoadModeTypesInfo {
+		return
+	}
+	hasTypes := pkg.Types != nil
+	hasTypesInfo := pkg.TypesInfo != nil
+	if !hasTypes || !hasTypesInfo {
+		tb.Fatalf("package %q missing type information", pkg.PkgPath)
+	}
+}
+
+func newPackageSnapshot(pkg *packages.Package) PackageSnapshot {
+	return PackageSnapshot{
+		Fset:      pkg.Fset,
+		Files:     pkg.Syntax,
+		Path:      pkg.PkgPath,
+		ReadFile:  os.ReadFile,
+		Types:     pkg.Types,
+		TypesInfo: pkg.TypesInfo,
+	}
+}
+
+// discardDiagnostic satisfies analysis.Pass.Report in benchmarks that ignore
+// reported diagnostics.
+func discardDiagnostic(diagnostic analysis.Diagnostic) {
+	_ = diagnostic
+}
+
 func NewPass(snapshot PackageSnapshot, analyzer *analysis.Analyzer, report func(analysis.Diagnostic)) *analysis.Pass {
 	if report == nil {
-		report = func(analysis.Diagnostic) {}
+		report = discardDiagnostic
 	}
+	// Syntax-mode snapshots leave Pkg and TypesInfo nil. That covers analyzers
+	// that read parsed files and lexical scope.
 	return &analysis.Pass{
 		Analyzer:  analyzer,
 		Fset:      snapshot.Fset,

--- a/plugin/benchmark_test.go
+++ b/plugin/benchmark_test.go
@@ -2,9 +2,16 @@ package plugin
 
 import (
 	"fmt"
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/tobythehutt/anyguard/v2/internal/benchtest"
@@ -14,32 +21,201 @@ import (
 const errUnexpectedSmokeDiagnosticCount = "unexpected smoke diagnostic count: got %d want %d"
 const expectedSmokeDiagnosticCount = 5
 
+type smokeBenchmarkCase struct {
+	name     string
+	loadMode benchtest.PackageLoadMode
+}
+
 func BenchmarkModulePluginSmokePath(b *testing.B) {
 	smokeRoot := benchtest.CopyModuleTree(b, filepath.Join("..", "testdata", "golangci", "smoke"))
 	patterns := smokePackagePatterns(b, smokeRoot)
-	snapshots := benchtest.LoadPackageSnapshots(b, smokeRoot, patterns)
-	settings := map[string]any{
+	pluginSettings := map[string]any{
 		flagAllowlist: "any_allowlist.yaml",
 		flagRepoRoot:  smokeRoot,
 		flagRoots:     []any{"./..."},
 	}
 
-	expectedDiagnostics := benchmarkSmokeDiagnostics(b, settings, snapshots)
-	// The checked-in smoke fixture currently emits five diagnostics, matching the
-	// shell smoke script assertions under scripts/ci/run-golangci-plugin-smoke.sh.
-	if got, want := expectedDiagnostics, expectedSmokeDiagnosticCount; got != want {
-		b.Fatalf(errUnexpectedSmokeDiagnosticCount, got, want)
+	benchmarkCases := []smokeBenchmarkCase{
+		{name: "syntax-load", loadMode: benchtest.PackageLoadModeSyntax},
+		{name: "typesinfo-load-baseline", loadMode: benchtest.PackageLoadModeTypesInfo},
+	}
+	for _, benchmarkCase := range benchmarkCases {
+		benchmarkModulePluginSmokePath(b, smokeRoot, patterns, pluginSettings, benchmarkCase)
+	}
+}
+
+func benchmarkModulePluginSmokePath(
+	b *testing.B,
+	smokeRoot string,
+	patterns []string,
+	settings map[string]any,
+	benchmarkCase smokeBenchmarkCase,
+) {
+	b.Helper()
+
+	snapshots := loadSmokeSnapshots(b, smokeRoot, patterns, benchmarkCase.loadMode)
+	diagnosticCount := benchmarkSmokeDiagnostics(b, settings, snapshots)
+	expectedDiagnosticCount := expectedSmokeDiagnosticCount
+	// The checked-in smoke fixture emits five diagnostics. The shell smoke script
+	// checks the same count.
+	if diagnosticCount != expectedDiagnosticCount {
+		b.Fatalf(errUnexpectedSmokeDiagnosticCount, diagnosticCount, expectedDiagnosticCount)
 	}
 
-	name := fmt.Sprintf("smoke-%dpkgs-%ddiagnostics", len(snapshots), expectedDiagnostics)
-	b.Run(name, func(b *testing.B) {
+	snapshotCount := len(snapshots)
+	benchmarkName := fmt.Sprintf("%s-%dpkgs-%ddiagnostics", benchmarkCase.name, snapshotCount, diagnosticCount)
+	b.Run(benchmarkName, func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			if got := benchmarkSmokeDiagnostics(b, settings, snapshots); got != expectedDiagnostics {
-				b.Fatalf(errUnexpectedSmokeDiagnosticCount, got, expectedDiagnostics)
+			// Each iteration reloads package inputs. The benchmark includes the
+			// package work selected by the module-plugin load mode.
+			reloadedSnapshots := loadSmokeSnapshots(b, smokeRoot, patterns, benchmarkCase.loadMode)
+			reloadedDiagnosticCount := benchmarkSmokeDiagnostics(b, settings, reloadedSnapshots)
+			if reloadedDiagnosticCount != expectedDiagnosticCount {
+				b.Fatalf(errUnexpectedSmokeDiagnosticCount, reloadedDiagnosticCount, expectedDiagnosticCount)
 			}
 		}
 	})
+}
+
+// loadSmokeSnapshots mirrors the module-plugin split. Both modes parse files.
+// The typesinfo baseline adds type checking on top of that parse step.
+func loadSmokeSnapshots(tb testing.TB, smokeRoot string, patterns []string, loadMode benchtest.PackageLoadMode) []benchtest.PackageSnapshot {
+	tb.Helper()
+
+	goVersion := loadSmokeGoVersion(tb, smokeRoot)
+	snapshotCount := len(patterns)
+	snapshots := make([]benchtest.PackageSnapshot, 0, snapshotCount)
+	for _, pattern := range patterns {
+		snapshot := loadSmokeSnapshot(tb, smokeRoot, pattern, loadMode, goVersion)
+		snapshots = append(snapshots, snapshot)
+	}
+	sort.Slice(snapshots, func(i, j int) bool {
+		return snapshots[i].Path < snapshots[j].Path
+	})
+	return snapshots
+}
+
+func loadSmokeSnapshot(
+	tb testing.TB,
+	smokeRoot string,
+	pattern string,
+	loadMode benchtest.PackageLoadMode,
+	goVersion string,
+) benchtest.PackageSnapshot {
+	tb.Helper()
+
+	packagePath := strings.TrimPrefix(pattern, "./")
+	normalizedPackagePath := filepath.FromSlash(packagePath)
+	packageDir := filepath.Join(smokeRoot, normalizedPackagePath)
+	fset := token.NewFileSet()
+	syntaxFiles := parseSmokePackageFiles(tb, fset, packageDir)
+	snapshot := benchtest.PackageSnapshot{
+		Fset:     fset,
+		Files:    syntaxFiles,
+		Path:     pattern,
+		ReadFile: os.ReadFile,
+	}
+	if loadMode != benchtest.PackageLoadModeTypesInfo {
+		return snapshot
+	}
+
+	typesPkg, typesInfo := typeCheckSmokePackage(tb, fset, pattern, syntaxFiles, goVersion)
+	snapshot.Types = typesPkg
+	snapshot.TypesInfo = typesInfo
+	return snapshot
+}
+
+func parseSmokePackageFiles(tb testing.TB, fset *token.FileSet, packageDir string) []*ast.File {
+	tb.Helper()
+
+	entries, err := os.ReadDir(packageDir)
+	if err != nil {
+		tb.Fatalf("read smoke package dir: %v", err)
+	}
+
+	files := make([]*ast.File, 0, len(entries))
+	for _, entry := range entries {
+		entryName := entry.Name()
+		isDir := entry.IsDir()
+		isGoFile := filepath.Ext(entryName) == ".go"
+		if isDir || !isGoFile {
+			continue
+		}
+		filePath := filepath.Join(packageDir, entryName)
+		syntax, parseErr := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
+		if parseErr != nil {
+			tb.Fatalf("parse smoke package file: %v", parseErr)
+		}
+		files = append(files, syntax)
+	}
+	if len(files) == 0 {
+		tb.Fatalf("expected go files in smoke package dir %q", packageDir)
+	}
+	return files
+}
+
+func typeCheckSmokePackage(
+	tb testing.TB,
+	fset *token.FileSet,
+	packagePath string,
+	syntaxFiles []*ast.File,
+	goVersion string,
+) (*types.Package, *types.Info) {
+	tb.Helper()
+
+	const errTypeCheckSmokePackage = "type check smoke package %q: %v"
+
+	packageName := syntaxFiles[0].Name.Name
+	typesPkg := types.NewPackage(packagePath, packageName)
+	typesInfo := &types.Info{
+		Types:        make(map[ast.Expr]types.TypeAndValue),
+		Instances:    make(map[*ast.Ident]types.Instance),
+		Defs:         make(map[*ast.Ident]types.Object),
+		Uses:         make(map[*ast.Ident]types.Object),
+		Implicits:    make(map[ast.Node]types.Object),
+		Selections:   make(map[*ast.SelectorExpr]*types.Selection),
+		Scopes:       make(map[ast.Node]*types.Scope),
+		FileVersions: make(map[*ast.File]string),
+	}
+	defaultImporter := importer.Default()
+	typeSizes := types.SizesFor("gc", runtime.GOARCH)
+	reportTypeError := func(err error) {
+		tb.Fatalf(errTypeCheckSmokePackage, packagePath, err)
+	}
+	config := &types.Config{
+		Importer:  defaultImporter,
+		Sizes:     typeSizes,
+		GoVersion: goVersion,
+		Error:     reportTypeError,
+	}
+	checker := types.NewChecker(config, fset, typesPkg, typesInfo)
+	if err := checker.Files(syntaxFiles); err != nil {
+		tb.Fatalf(errTypeCheckSmokePackage, packagePath, err)
+	}
+	return typesPkg, typesInfo
+}
+
+func loadSmokeGoVersion(tb testing.TB, smokeRoot string) string {
+	tb.Helper()
+
+	const goDirectivePrefix = "go "
+
+	goModPath := filepath.Join(smokeRoot, goModFileName)
+	// #nosec G304 -- goModPath is rooted under the copied benchmark fixture tree.
+	data, err := os.ReadFile(goModPath)
+	if err != nil {
+		tb.Fatalf("read smoke go.mod: %v", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, goDirectivePrefix) {
+			continue
+		}
+		return "go" + strings.TrimSpace(strings.TrimPrefix(trimmed, goDirectivePrefix))
+	}
+	tb.Fatalf("resolve smoke Go version from %q", goModPath)
+	return ""
 }
 
 func benchmarkSmokeDiagnostics(tb testing.TB, settings map[string]any, snapshots []benchtest.PackageSnapshot) int {
@@ -60,9 +236,11 @@ func benchmarkSmokeDiagnostics(tb testing.TB, settings map[string]any, snapshots
 
 	diagnosticCount := 0
 	for _, snapshot := range snapshots {
-		pass := benchtest.NewPass(snapshot, analyzers[0], func(analysis.Diagnostic) {
+		countDiagnostic := func(analysis.Diagnostic) {
 			diagnosticCount++
-		})
+		}
+		analyzer := analyzers[0]
+		pass := benchtest.NewPass(snapshot, analyzer, countDiagnostic)
 		_, runErr := analyzers[0].Run(pass)
 		if runErr != nil {
 			tb.Fatalf("run analyzer: %v", runErr)
@@ -81,8 +259,11 @@ func smokePackagePatterns(tb testing.TB, smokeRoot string) []string {
 
 	patterns := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		if entry.IsDir() {
-			patterns = append(patterns, "./pkg/"+entry.Name())
+		isDir := entry.IsDir()
+		if isDir {
+			entryName := entry.Name()
+			pattern := "./pkg/" + entryName
+			patterns = append(patterns, pattern)
 		}
 	}
 	sort.Strings(patterns)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -94,7 +94,7 @@ func (p *ModulePlugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
 
 // GetLoadMode declares the package loading mode required by this analyzer.
 func (p *ModulePlugin) GetLoadMode() string {
-	return register.LoadModeTypesInfo
+	return register.LoadModeSyntax
 }
 
 func normalizeRoots(roots []string) []string {

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -1,22 +1,39 @@
 package plugin
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/golangci/plugin-module-register/register"
+	"github.com/tobythehutt/anyguard/v2/internal/benchtest"
+	"golang.org/x/tools/go/analysis"
 )
 
 const (
 	errNewPlugin           = "new plugin: %v"
 	errBuildAnalyzers      = "build analyzers: %v"
 	errExpectedOneAnalyzer = "expected one analyzer, got %d"
+	errRunAnalyzer         = "run analyzer: %v"
 	flagAllowlist          = "allowlist"
 	flagRepoRoot           = "repo-root"
 	flagRoots              = "roots"
+	goModFileName          = "go.mod"
+	valueRootAll           = "./..."
+	valueRootPackage       = "pkg/api"
 	valueAnyAllowlist      = "ci/allowlist.yaml"
 	valueRepoRoot          = "/repo/root"
-	valueRoots             = "./...,pkg/api"
+	valueRoots             = valueRootAll + "," + valueRootPackage
+	syntaxTestRoots        = valueRootAll
+	syntaxTestAllowlist    = "allowlist.yaml"
+	syntaxTestAllowlistYML = "version: 2\nentries: []\n"
+	syntaxTestGoMod        = "module example.com/pluginsyntax\n\ngo 1.22.0\n"
+	syntaxTestPackage      = "./pkg"
+	syntaxTestSourcePath   = "pkg/payload.go"
+	syntaxTestSource       = "package pkg\n\ntype Payload map[string]any\n\nfunc Shadowed(values []int) {\n\tany := 0\n\t_ = values[any]\n}\n"
+	syntaxTestLine         = 3
+	syntaxTestColumn       = 25
 )
 
 func TestInitRegistersPlugin(t *testing.T) {
@@ -45,7 +62,7 @@ func TestModulePluginBuildAnalyzers(t *testing.T) {
 	pluginInstance, err := New(map[string]any{
 		flagAllowlist: valueAnyAllowlist,
 		flagRepoRoot:  valueRepoRoot,
-		flagRoots:     []any{"./...", "pkg/api"},
+		flagRoots:     []any{valueRootAll, valueRootPackage},
 	})
 	if err != nil {
 		t.Fatalf(errNewPlugin, err)
@@ -81,8 +98,88 @@ func TestModulePluginGetLoadMode(t *testing.T) {
 		t.Fatalf(errNewPlugin, err)
 	}
 
-	if got, want := pluginInstance.GetLoadMode(), register.LoadModeTypesInfo; got != want {
+	if got, want := pluginInstance.GetLoadMode(), register.LoadModeSyntax; got != want {
 		t.Fatalf("unexpected load mode: got %q want %q", got, want)
+	}
+}
+
+// This test locks the plugin to passes with parsed files and no type data.
+func TestModulePluginRunsOnSyntaxPass(t *testing.T) {
+	repoRoot := t.TempDir()
+	allowlistPath := syntaxTestAllowlist
+	sourcePath := syntaxTestSourcePath
+	packagePatterns := []string{syntaxTestPackage}
+	loadMode := benchtest.PackageLoadModeSyntax
+
+	writePluginFixtureFile(t, repoRoot, goModFileName, syntaxTestGoMod)
+	writePluginFixtureFile(t, repoRoot, allowlistPath, syntaxTestAllowlistYML)
+	writePluginFixtureFile(t, repoRoot, sourcePath, syntaxTestSource)
+
+	snapshots := benchtest.LoadPackageSnapshotsWithMode(
+		t,
+		repoRoot,
+		packagePatterns,
+		loadMode,
+	)
+	snapshotCount := len(snapshots)
+	expectedSnapshotCount := 1
+	if snapshotCount != expectedSnapshotCount {
+		t.Fatalf("unexpected snapshot count: got %d want %d", snapshotCount, expectedSnapshotCount)
+	}
+
+	snapshot := snapshots[0]
+	if snapshot.Types != nil {
+		t.Fatalf("expected syntax snapshot to leave package types nil")
+	}
+	if snapshot.TypesInfo != nil {
+		t.Fatalf("expected syntax snapshot to leave types info nil")
+	}
+
+	settings := map[string]any{
+		flagAllowlist: allowlistPath,
+		flagRepoRoot:  repoRoot,
+		flagRoots:     []any{syntaxTestRoots},
+	}
+	pluginInstance, err := New(settings)
+	if err != nil {
+		t.Fatalf(errNewPlugin, err)
+	}
+
+	analyzers, err := pluginInstance.BuildAnalyzers()
+	if err != nil {
+		t.Fatalf(errBuildAnalyzers, err)
+	}
+	analyzerCount := len(analyzers)
+	expectedAnalyzerCount := 1
+	if analyzerCount != expectedAnalyzerCount {
+		t.Fatalf(errExpectedOneAnalyzer, analyzerCount)
+	}
+
+	analyzer := analyzers[0]
+	diagnostics := collectPluginDiagnostics(t, analyzer, snapshot)
+	diagnosticCount := len(diagnostics)
+	expectedDiagnosticCount := 1
+	if diagnosticCount != expectedDiagnosticCount {
+		t.Fatalf("unexpected diagnostic count: got %d want %d", diagnosticCount, expectedDiagnosticCount)
+	}
+
+	diagnostic := diagnostics[0]
+	position := snapshot.Fset.PositionFor(diagnostic.Pos, false)
+	expectedFile := filepath.Join(repoRoot, sourcePath)
+	gotFile := filepath.ToSlash(position.Filename)
+	wantFile := filepath.ToSlash(expectedFile)
+	if gotFile != wantFile {
+		t.Fatalf("unexpected diagnostic file: got %q want %q", gotFile, wantFile)
+	}
+	gotLine := position.Line
+	wantLine := syntaxTestLine
+	if gotLine != wantLine {
+		t.Fatalf("unexpected diagnostic line: got %d want %d", gotLine, wantLine)
+	}
+	gotColumn := position.Column
+	wantColumn := syntaxTestColumn
+	if gotColumn != wantColumn {
+		t.Fatalf("unexpected diagnostic column: got %d want %d", gotColumn, wantColumn)
 	}
 }
 
@@ -94,13 +191,13 @@ func TestRootsSettingUnmarshal(t *testing.T) {
 	}{
 		{
 			name: "list",
-			raw:  map[string]any{"roots": []any{"./...", " pkg/api ", ""}},
-			want: []string{"./...", "pkg/api"},
+			raw:  map[string]any{"roots": []any{valueRootAll, " " + valueRootPackage + " ", ""}},
+			want: []string{valueRootAll, valueRootPackage},
 		},
 		{
 			name: "csv",
-			raw:  map[string]any{"roots": " ./..., pkg/api "},
-			want: []string{"./...", "pkg/api"},
+			raw:  map[string]any{"roots": " " + valueRootAll + ", " + valueRootPackage + " "},
+			want: []string{valueRootAll, valueRootPackage},
 		},
 	}
 
@@ -119,5 +216,34 @@ func TestRootsSettingUnmarshal(t *testing.T) {
 				t.Fatalf("roots mismatch: got %v want %v", got, testCase.want)
 			}
 		})
+	}
+}
+
+func collectPluginDiagnostics(t *testing.T, analyzer *analysis.Analyzer, snapshot benchtest.PackageSnapshot) []analysis.Diagnostic {
+	t.Helper()
+
+	diagnostics := make([]analysis.Diagnostic, 0, 1)
+	recordDiagnostic := func(diagnostic analysis.Diagnostic) {
+		diagnostics = append(diagnostics, diagnostic)
+	}
+	pass := benchtest.NewPass(snapshot, analyzer, recordDiagnostic)
+	if _, err := analyzer.Run(pass); err != nil {
+		t.Fatalf(errRunAnalyzer, err)
+	}
+	return diagnostics
+}
+
+func writePluginFixtureFile(t *testing.T, root, relPath, content string) {
+	t.Helper()
+
+	normalizedPath := filepath.FromSlash(relPath)
+	path := filepath.Join(root, normalizedPath)
+	dirPath := filepath.Dir(path)
+	if err := os.MkdirAll(dirPath, 0o750); err != nil {
+		t.Fatalf("create plugin fixture dir: %v", err)
+	}
+	data := []byte(content)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write plugin fixture file: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- switch the golangci-lint module plugin from typesinfo to syntax load mode
- keep behavior stable with syntax-only plugin coverage for a supported slot and a shadowed any case
- update smoke benchmarking, docs, and release notes for the lexical-resolution-based safety argument

Resolves: #68 

## Benchmark
- syntax-load: about 115–123µs/op, 38.7 KB/op, 504 allocs/op
- typesinfo baseline: about 171–186µs/op, 65.4 KB/op, 825 allocs/op