### PR TITLE
70 repo performance guardrail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,32 @@ jobs:
       - name: Run tests with race detector
         run: go test -race -v ./...
 
-      - name: Run benchmarks
-        run: go test -bench=. -run=^$ ./...
+  perf-sanity:
+    name: Perf Sanity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.x"
+
+      - name: Get dependencies
+        run: go get -v -t -d ./...
+
+      - name: Benchmark repo-wide validation
+        run: go test -run=^$ -bench=BenchmarkCheckedInRepoValidation -benchmem -benchtime=1x ./internal/validation
+
+      - name: Benchmark analyzer cold pass
+        run: go test -run=^$ -bench=BenchmarkCheckedInRepoAnalyzerColdPass -benchmem -benchtime=1x ./internal/validation
+
+      - name: Benchmark analyzer warm pass
+        run: go test -run=^$ -bench=BenchmarkCheckedInRepoAnalyzerWarmPass -benchmem -benchtime=1x ./internal/validation
+
+      - name: Benchmark module-plugin path
+        run: go test -run=^$ -bench=BenchmarkCheckedInRepoModulePluginPath -benchmem -benchtime=1x ./plugin
 
   lint:
     name: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,16 +47,10 @@ jobs:
       - name: Get dependencies
         run: go get -v -t -d ./...
 
-      - name: Benchmark repo-wide validation
-        run: go test -run=^$ -bench=BenchmarkCheckedInRepoValidation -benchmem -benchtime=1x ./internal/validation
+      - name: Benchmark validation perf sanity
+        run: go test -run=^$ -bench='BenchmarkCheckedInRepoValidation|BenchmarkCheckedInRepoAnalyzerColdPass|BenchmarkCheckedInRepoAnalyzerWarmPass' -benchmem -benchtime=1x ./internal/validation
 
-      - name: Benchmark analyzer cold pass
-        run: go test -run=^$ -bench=BenchmarkCheckedInRepoAnalyzerColdPass -benchmem -benchtime=1x ./internal/validation
-
-      - name: Benchmark analyzer warm pass
-        run: go test -run=^$ -bench=BenchmarkCheckedInRepoAnalyzerWarmPass -benchmem -benchtime=1x ./internal/validation
-
-      - name: Benchmark module-plugin path
+      - name: Benchmark plugin perf sanity
         run: go test -run=^$ -bench=BenchmarkCheckedInRepoModulePluginPath -benchmem -benchtime=1x ./plugin
 
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on Keep a Changelog, with the current development state trac
 - Added GitHub generated release-note configuration and label guidance without replacing the curated changelog. (@TobyTheHutt)
 - Added exclude-glob microbenchmarks that compare the previous per-file regex compilation path with reused compiled matchers. (@TobyTheHutt)
 - Added analyzer benchmarks for cold passes, reused passes, and warmed-cache passes. (@TobyTheHutt)
+- Added checked-in repo perf-sanity benchmarks, CI commands, and an analyzer-sweep regression test for repo-wide validation, cold and warm analyzer passes, and module-plugin cost. (@TobyTheHutt)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Nested `any` is reportable only when the nested identifier still appears in one 
 go test ./...
 
 # Run focused execution-model contract tests
-go test ./internal/validation -run 'TestValidateAnyUsageAuditsWholeRepo|TestAnalyzerRunUsesRepoWideAllowlistValidation|TestAnalyzerRunReportsPackageLocalDiagnosticsAndReusesRepoValidation'
+go test ./internal/validation -run 'TestValidateAnyUsageAuditsWholeRepo|TestAnalyzerRunUsesRepoWideAllowlistValidation|TestAnalyzerRunReportsPackageLocalDiagnosticsAndReusesRepoValidation|TestCheckedInRepoAnalyzerReusesRepoValidationAcrossPackageSweep'
 
 # Run benchmarks
 go test -bench=. ./...
@@ -206,8 +206,14 @@ go test -bench=. ./...
 # Benchmark only (skip unit tests)
 go test -bench=. -run=^$ ./...
 
-# Run focused perf-sanity benchmarks
-go test -run=^$ -bench='BenchmarkAnalyzerRun|BenchmarkModulePluginSmokePath' -benchtime=1x ./internal/validation ./plugin
+# Run checked-in repo perf-sanity benchmarks
+go test -run=^$ -bench=BenchmarkCheckedInRepoValidation -benchmem -benchtime=1x ./internal/validation
+go test -run=^$ -bench=BenchmarkCheckedInRepoAnalyzerColdPass -benchmem -benchtime=1x ./internal/validation
+go test -run=^$ -bench=BenchmarkCheckedInRepoAnalyzerWarmPass -benchmem -benchtime=1x ./internal/validation
+go test -run=^$ -bench=BenchmarkCheckedInRepoModulePluginPath -benchmem -benchtime=1x ./plugin
+
+# Run the deterministic module-plugin smoke benchmark
+go test -run=^$ -bench=BenchmarkModulePluginSmokePath -benchmem -benchtime=1x ./plugin
 
 # Run lint
 golangci-lint run
@@ -216,7 +222,17 @@ golangci-lint run
 bash scripts/ci/run-golangci-plugin-smoke.sh
 ```
 
-The benchmark suite includes `ValidateAnyUsage`, repo-wide finding collection and allowlist resolution helpers, analyzer `Run` in `cold-pass` and `reused-pass` modes, and the golangci-lint module-plugin smoke path. The focused execution-model tests and perf-sanity benchmarks above are the maintainers' contract for package-local analyzer diagnostics plus repo-wide stale-selector validation.
+The perf-sanity commands above separate the costs that matter during release reviews:
+
+| Benchmark | Measures |
+| --- | --- |
+| `BenchmarkCheckedInRepoValidation` | Whole-repo audit on this checkout: root resolution, build-aware walk, parsing, finding collection, and allowlist resolution. |
+| `BenchmarkCheckedInRepoAnalyzerColdPass` | First analyzer sweep after clearing the shared repo-validation cache. |
+| `BenchmarkCheckedInRepoAnalyzerWarmPass` | Analyzer sweep after repo-wide validation is already cached. |
+| `BenchmarkCheckedInRepoModulePluginPath` | Syntax-load module-plugin sweep across this checkout with package reloads each iteration. |
+| `BenchmarkModulePluginSmokePath` | Small smoke fixture for plugin ordering and syntax-vs-types baselines. |
+
+Use `BenchmarkModulePluginSmokePath` for quick local iteration. Use `BenchmarkCheckedInRepoModulePluginPath` in CI and regression checks.
 
 ### golangci-lint integration
 

--- a/docs/golangci-lint/README.md
+++ b/docs/golangci-lint/README.md
@@ -6,10 +6,7 @@
 - Plugin import path: `github.com/tobythehutt/anyguard/v2/plugin`
 - Linter name in `.golangci.yml`: `anyguard`
 - Module-plugin diagnostics follow the same deterministic ordering compatibility guarantee as the CLI and public analyzer.
-- The plugin uses the same AST-slot-driven contract as the CLI and public analyzer.
-- It requests golangci-lint `syntax` load mode. Supported-slot matching, shadowed-`any` suppression, and repo-wide stale-selector validation use parsed syntax plus lexical scope resolution rather than `types.Info`.
-- It reports `any` in supported AST child slots, and every supported slot uses lexical resolution of the universe `any` alias to suppress shadowed declarations.
-- The detection contract distinguishes dedicated type-position slots from the three compatibility slots, and there are no syntax-only slots left in the implementation.
+- The root README is the canonical reference for behavior and detection scope: [`Execution Model`](../../README.md#execution-model), [`Detection Contract`](../../README.md#detection-contract).
 
 ## Build a custom golangci-lint
 
@@ -54,50 +51,50 @@ linters:
 
 ## Execution model
 
-- Analyzer/plugin path: golangci-lint loads `anyguard` as a `go/analysis` linter and runs one pass per package. Each pass reports only the findings owned by that package after applying the configured roots and `exclude_globs` to the same canonical repository-relative file identities used by repo-wide allowlist resolution. The shared repo validation result keeps repo-wide findings indexed by canonical repository-relative path, so later package passes filter cached findings instead of repeating package-local AST-slot collection.
-- Repo-wide stale-selector validation still happens in that mode. The allowlist is resolved against repo-wide findings across the configured roots once per golangci-lint process and reused by later package passes.
-- Audit path: the repo-wide validation helper used by this repository's tests and benchmarks walks the configured roots once, applies the active Go build context (`//go:build`, `GOOS`, `GOARCH`, `GOFLAGS=-tags=...`, file suffix constraints, and `CGO_ENABLED`), and returns the full violation set. That is the whole-repo audit reference point. The module plugin does not repeat that work on every package.
+- golangci-lint runs `anyguard` as one `go/analysis` pass per package.
+- Diagnostics stay package-local after applying the configured roots and `exclude_globs`.
+- Repo-wide stale-selector validation is resolved once per golangci-lint process and reused across later package passes.
+- The root README [`Execution Model`](../../README.md#execution-model) section is the canonical reference for the full model.
 
 ## Load mode and performance
 
 - The module plugin requires `syntax` load mode.
-- This skips golangci-lint package type checking before `anyguard` runs. Matching, shadowed-`any` suppression, and stale-selector validation do not consume `types.Info`.
-- The plugin also pays one repo-wide allowlist-validation cost per golangci-lint process so stale selectors remain fail-closed across the configured roots.
-- It does not run a whole-repo diagnostic audit on every package. Only current-package diagnostics are emitted per pass.
-- Compared with the audit path, the tradeoff is lower per-package front-end cost but no repeated repo scan for every package.
-- Module-plugin diagnostics stay sorted by `file`, `line`, `column`, `category`, and `owner`, independent of configured root order, filesystem traversal order, and map iteration.
-- Canonical finding identity and exact allowlist matching include `line` and `column` coordinates.
-- Legacy allowlist selectors that omit coordinates are accepted only when `{path, owner, category}` still resolves to exactly one current finding.
+- Matching, shadowed-`any` suppression, and stale-selector validation do not consume `types.Info`.
+- The plugin pays one repo-wide allowlist-validation cost per golangci-lint process and does not rerun a whole-repo diagnostic audit on every package.
+- Finding identity and reporting order stay exact and deterministic: `file`, `line`, `column`, `category`, `owner`.
 - Measure the repository smoke path with:
 
 ```bash
 /usr/bin/time -f 'elapsed=%E maxrss=%MKB' bash scripts/ci/run-golangci-plugin-smoke.sh
 ```
 
+- Checked-in repo module-plugin regression baseline:
+
+```bash
+go test -run=^$ -bench=BenchmarkCheckedInRepoModulePluginPath -benchmem -benchtime=1x ./plugin
+```
+
 - Run the focused execution-model contract tests with:
 
 ```bash
-go test ./internal/validation -run 'TestValidateAnyUsageAuditsWholeRepo|TestAnalyzerRunUsesRepoWideAllowlistValidation|TestAnalyzerRunReportsPackageLocalDiagnosticsAndReusesRepoValidation'
+go test ./internal/validation -run 'TestValidateAnyUsageAuditsWholeRepo|TestAnalyzerRunUsesRepoWideAllowlistValidation|TestAnalyzerRunReportsPackageLocalDiagnosticsAndReusesRepoValidation|TestCheckedInRepoAnalyzerReusesRepoValidationAcrossPackageSweep'
 ```
 
-- Measure the local module-plugin benchmark path without building `custom-gcl`:
+- Run the deterministic local module-plugin smoke benchmark without building `custom-gcl`:
 
 ```bash
-go test -bench=ModulePluginSmokePath -run=^$ ./plugin
+go test -run=^$ -bench=BenchmarkModulePluginSmokePath -benchmem -benchtime=1x ./plugin
 ```
 
-- Run the focused analyzer/plugin perf-sanity benchmarks with:
+- Use `BenchmarkCheckedInRepoModulePluginPath` in CI and regression checks.
 
-```bash
-go test -run=^$ -bench='BenchmarkAnalyzerRun|BenchmarkModulePluginSmokePath' -benchtime=1x ./internal/validation ./plugin
-```
+- For the full perf-sanity suite and benchmark meanings, see the root README [`Development`](../../README.md#development) section.
 
 ## Upstream readiness
 
 For maintainers evaluating possible core inclusion:
 
 - The normative spec is the root [`Behavior`](../../README.md#behavior), [`Comparison With Generic Ban-Pattern Linters`](../../README.md#comparison-with-generic-ban-pattern-linters), [`Allowlist Schema`](../../README.md#allowlist-schema), and [`Detection Contract`](../../README.md#detection-contract).
-- Supported syntax categories are exactly the AST child slots in the detection contract. Every supported slot uses lexical resolution of the universe `any` alias. The only slots outside dedicated type positions are the three compatibility slots. Anything outside that list is out of scope and intentionally silent.
 - The module plugin uses golangci-lint `syntax` load mode. Supported-slot matching, shadowed-`any` suppression, and repo-wide stale-selector validation run from parsed syntax plus lexical scope state rather than `types.Info`.
 - Each finding has one exact identity: `{path, owner, category, line, column}`. Allowlist matching is exact on that identity.
 - Legacy selectors without `line` and `column` are accepted only when their `{path, owner, category}` triple still resolves to exactly one current finding.
@@ -105,10 +102,6 @@ For maintainers evaluating possible core inclusion:
 - The analyzer fails closed on unresolved file identity, allowlist parse/validation errors, stale or ambiguous selectors, and traversal or parse failures.
 - CLI, analyzer, and module-plugin reporting order is a compatibility guarantee: no scoring, no heuristic ranking, and stable sort order by `file`, `line`, `column`, `category`, and `owner`.
 - Ordering does not depend on configured root order, filesystem traversal order, or map iteration.
-- False positives should mostly come down to scope. There are no syntax-only slots. `*ast.CallExpr.Fun`, `*ast.IndexExpr.Index`, and `*ast.IndexListExpr.Indices[i]` remain supported compatibility slots, so cases such as `any(1)`, `Single[any]{}`, and `Box[int, any]{}` remain reportable by contract.
-- Allowlist strictness is deliberate in schema version `2`: no broad file-level or owner-only exceptions, no duplicate selectors, no half-specified selector coordinates, and no selectors that fail to resolve to a current finding.
-- Non-goals: type-parameter constraints, broader unsafe-dynamic-use detection, or claims that every finding is a bug or security issue.
-- The root comparison section is the canonical answer to "why not just use an existing ban-pattern linter?": overlap exists at the policy level, but `anyguard` is specifically about exact exceptions, stale-selector rejection, and a documented syntax-slot contract.
 - Treat this as a policy linter, not a detector. It enforces repository policy over `any`. Upstream inclusion is still not guaranteed.
 
 ## Run

--- a/internal/benchtest/benchtest.go
+++ b/internal/benchtest/benchtest.go
@@ -8,6 +8,7 @@ import (
 	"go/types"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -92,6 +93,14 @@ type SyntheticRepo struct {
 	Stats                 RepoStats
 }
 
+type CheckedInRepo struct {
+	AllowlistPath    string
+	AllowlistRelPath string
+	PackagePatterns  []string
+	Root             string
+	Roots            []string
+}
+
 type PackageSnapshot struct {
 	Fset      *token.FileSet
 	Files     []*ast.File
@@ -172,6 +181,82 @@ func CopyModuleTree(tb testing.TB, srcRoot string) string {
 	return dstRoot
 }
 
+// CurrentCheckedInRepo resolves the repository rooted at the checked-in source
+// tree so benchmarks can measure the current checkout without generating a
+// synthetic fixture.
+func CurrentCheckedInRepo(tb testing.TB) CheckedInRepo {
+	tb.Helper()
+
+	repoRoot := resolveCheckedInRepoRoot(tb)
+	goModPath := filepath.Join(repoRoot, goModFileName)
+	if !checkedInRepoFileExists(goModPath) {
+		tb.Fatalf("expected checked-in repo go.mod at %q", goModPath)
+	}
+
+	allowlistRelPath := defaultAllowlistPath
+	allowlistPath := filepath.Join(repoRoot, filepath.FromSlash(allowlistRelPath))
+	if !checkedInRepoFileExists(allowlistPath) {
+		tb.Fatalf("expected checked-in repo allowlist at %q", allowlistPath)
+	}
+
+	packagePatterns := []string{defaultConfiguredRoot}
+	roots := []string{defaultConfiguredRoot}
+	return CheckedInRepo{
+		AllowlistPath:    allowlistPath,
+		AllowlistRelPath: allowlistRelPath,
+		PackagePatterns:  packagePatterns,
+		Root:             repoRoot,
+		Roots:            roots,
+	}
+}
+
+func resolveCheckedInRepoRoot(tb testing.TB) string {
+	tb.Helper()
+
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		tb.Fatal("resolve checked-in repo root: runtime caller unavailable")
+	}
+
+	sourceDir := filepath.Dir(sourceFile)
+	searchDir := sourceDir
+	for {
+		goModPath := filepath.Join(searchDir, goModFileName)
+		gitDirPath := filepath.Join(searchDir, ".git")
+		hasGoMod := checkedInRepoFileExists(goModPath)
+		hasGitDir := checkedInRepoDirExists(gitDirPath)
+		if hasGoMod || hasGitDir {
+			repoRoot := searchDir
+			return repoRoot
+		}
+
+		parentDir := filepath.Dir(searchDir)
+		if parentDir == searchDir {
+			break
+		}
+		searchDir = parentDir
+	}
+
+	tb.Fatalf("resolve checked-in repo root: no repo marker found while walking upward from %q", sourceDir)
+	return ""
+}
+
+func checkedInRepoFileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func checkedInRepoDirExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+
 func copyModuleTreeEntry(srcRoot, dstRoot, path string, entry os.DirEntry, walkErr error) error {
 	if walkErr != nil {
 		return walkErr
@@ -233,6 +318,10 @@ func LoadPackageSnapshotsWithMode(
 
 	snapshots := make([]PackageSnapshot, 0, len(pkgs))
 	for _, pkg := range pkgs {
+		if shouldSkipSnapshotPackage(pkg) {
+			continue
+		}
+
 		validateSnapshotPackage(tb, pkg, loadMode)
 		snapshots = append(snapshots, newPackageSnapshot(pkg))
 	}
@@ -249,6 +338,23 @@ func snapshotPackageLoadMode(loadMode PackageLoadMode) packages.LoadMode {
 		mode = packageLoadModeSyntax
 	}
 	return mode
+}
+
+func shouldSkipSnapshotPackage(pkg *packages.Package) bool {
+	if pkg == nil {
+		return true
+	}
+
+	hasGoFiles := len(pkg.GoFiles) > 0
+	hasCompiledGoFiles := len(pkg.CompiledGoFiles) > 0
+	if hasGoFiles || hasCompiledGoFiles {
+		return false
+	}
+
+	// Some `./...` sweeps include test-only packages with no ordinary source
+	// files. Analyzer and module-plugin passes do not run on those empty inputs.
+	hasSyntax := len(pkg.Syntax) > 0
+	return !hasSyntax
 }
 
 func validateSnapshotPackage(tb testing.TB, pkg *packages.Package, loadMode PackageLoadMode) {

--- a/internal/ci/any_allowlist.yaml
+++ b/internal/ci/any_allowlist.yaml
@@ -6,6 +6,6 @@ entries:
       path: internal/validation/analyzer.go
       owner: analyzerConfig
       category: "*ast.Field.Type"
-      line: 84
+      line: 79
       column: 54
     description: go/analysis Run API requires returning `any`

--- a/internal/validation/benchmark_test.go
+++ b/internal/validation/benchmark_test.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/tobythehutt/anyguard/v2/internal/benchtest"
@@ -9,12 +10,26 @@ import (
 )
 
 const (
-	errBenchmarkValidateAnyUsage   = "validate any usage: %v"
-	errBenchmarkCollectFindings    = "collect findings: %v"
-	errBenchmarkResolveAllowlist   = "resolve allowlist index: %v"
-	errBenchmarkRunAnalyzer        = "run analyzer: %v"
-	errExpectedAnalyzerDiagnostics = "expected analyzer diagnostics for benchmark fixture"
+	errBenchmarkValidateAnyUsage          = "validate any usage: %v"
+	errBenchmarkCollectFindings           = "collect findings: %v"
+	errBenchmarkResolveAllowlist          = "resolve allowlist index: %v"
+	errBenchmarkRunAnalyzer               = "run analyzer: %v"
+	errExpectedAnalyzerDiagnostics        = "expected analyzer diagnostics for benchmark fixture"
+	errExpectedCheckedInRepoFindings      = "expected checked-in repo benchmark to include repo-wide findings"
+	errUnexpectedCheckedInRepoViolations  = "unexpected checked-in repo violation count: got %d want %d"
+	errUnexpectedCheckedInRepoDiagnostics = "unexpected checked-in repo diagnostic count: got %d want %d"
 )
+
+type checkedInRepoBenchmarkFixture struct {
+	allowlistPath          string
+	allowlistRelPath       string
+	expectedViolationCount int
+	findingCount           int
+	packageCount           int
+	repoRoot               string
+	roots                  []string
+	snapshots              []benchtest.PackageSnapshot
+}
 
 func BenchmarkValidateAnyUsage(b *testing.B) {
 	fixture := benchtest.CreateSyntheticRepo(b, benchtest.DefaultSyntheticRepoConfig())
@@ -152,6 +167,90 @@ func BenchmarkAnalyzerRun(b *testing.B) {
 	})
 }
 
+func BenchmarkCheckedInRepoValidation(b *testing.B) {
+	fixture := loadCheckedInRepoBenchmarkFixture(b)
+	expectedViolationCount := fixture.expectedViolationCount
+	benchmarkName := checkedInRepoValidationBenchmarkName(
+		fixture.packageCount,
+		fixture.findingCount,
+		expectedViolationCount,
+	)
+
+	b.Run(benchmarkName, func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			gotViolations, validateErr := ValidateAnyUsageFromFile(
+				fixture.allowlistPath,
+				fixture.repoRoot,
+				fixture.roots,
+			)
+			if validateErr != nil {
+				b.Fatalf(errBenchmarkValidateAnyUsage, validateErr)
+			}
+
+			gotViolationCount := len(gotViolations)
+			if gotViolationCount != expectedViolationCount {
+				b.Fatalf(errUnexpectedCheckedInRepoViolations, gotViolationCount, expectedViolationCount)
+			}
+		}
+	})
+}
+
+func BenchmarkCheckedInRepoAnalyzerColdPass(b *testing.B) {
+	fixture := loadCheckedInRepoBenchmarkFixture(b)
+	cfg := checkedInRepoBenchmarkAnalyzerConfig(fixture)
+	expectedDiagnosticCount := benchmarkAnalyzerSweepDiagnostics(b, cfg, fixture.snapshots)
+	resetProcessRepoValidationCacheForTesting()
+
+	benchmarkName := checkedInRepoAnalyzerBenchmarkName(
+		fixture.packageCount,
+		fixture.findingCount,
+		expectedDiagnosticCount,
+	)
+	b.Run(benchmarkName, func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			resetProcessRepoValidationCacheForTesting()
+
+			diagnosticCount := benchmarkAnalyzerSweepDiagnostics(b, cfg, fixture.snapshots)
+			if diagnosticCount != expectedDiagnosticCount {
+				b.Fatalf(errUnexpectedCheckedInRepoDiagnostics, diagnosticCount, expectedDiagnosticCount)
+			}
+		}
+	})
+}
+
+func BenchmarkCheckedInRepoAnalyzerWarmPass(b *testing.B) {
+	fixture := loadCheckedInRepoBenchmarkFixture(b)
+	cfg := checkedInRepoBenchmarkAnalyzerConfig(fixture)
+	expectedDiagnosticCount := benchmarkAnalyzerSweepDiagnostics(b, cfg, fixture.snapshots)
+	resetProcessRepoValidationCacheForTesting()
+
+	// Warm the shared repo-validation cache once so the timed loop isolates the
+	// steady-state package-pass cost after repo-wide validation is already cached.
+	warmDiagnosticCount := benchmarkAnalyzerSweepDiagnostics(b, cfg, fixture.snapshots)
+	if warmDiagnosticCount != expectedDiagnosticCount {
+		b.Fatalf(errUnexpectedCheckedInRepoDiagnostics, warmDiagnosticCount, expectedDiagnosticCount)
+	}
+
+	benchmarkName := checkedInRepoAnalyzerBenchmarkName(
+		fixture.packageCount,
+		fixture.findingCount,
+		expectedDiagnosticCount,
+	)
+	b.Run(benchmarkName, func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			diagnosticCount := benchmarkAnalyzerSweepDiagnostics(b, cfg, fixture.snapshots)
+			if diagnosticCount != expectedDiagnosticCount {
+				b.Fatalf(errUnexpectedCheckedInRepoDiagnostics, diagnosticCount, expectedDiagnosticCount)
+			}
+		}
+	})
+}
+
 func benchmarkAllowlist(selectors []benchtest.Selector) AnyAllowlist {
 	entries := make([]AnyAllowlistEntry, 0, len(selectors))
 	for _, selector := range selectors {
@@ -194,6 +293,111 @@ func benchmarkAnalyzerDiagnostics(tb testing.TB, cfg *analyzerConfig, snapshot b
 		tb.Fatalf(errBenchmarkRunAnalyzer, err)
 	}
 	return diagnosticCount
+}
+
+func benchmarkAnalyzerSweepDiagnostics(
+	tb testing.TB,
+	cfg *analyzerConfig,
+	snapshots []benchtest.PackageSnapshot,
+) int {
+	tb.Helper()
+
+	totalDiagnostics := 0
+	for _, snapshot := range snapshots {
+		diagnosticCount := benchmarkAnalyzerDiagnostics(tb, cfg, snapshot)
+		totalDiagnostics += diagnosticCount
+	}
+	return totalDiagnostics
+}
+
+func loadCheckedInRepoBenchmarkFixture(tb testing.TB) checkedInRepoBenchmarkFixture {
+	tb.Helper()
+
+	checkedInRepo := benchtest.CurrentCheckedInRepo(tb)
+	buildCtx := currentBuildContext()
+	validationConfig, err := loadRepoValidationConfig(
+		checkedInRepo.Root,
+		checkedInRepo.Roots,
+		checkedInRepo.AllowlistPath,
+		buildCtx,
+	)
+	if err != nil {
+		tb.Fatalf("load checked-in repo validation config: %v", err)
+	}
+
+	repoResult, err := collectRepoValidationResultWithBuildContext(
+		validationConfig.repoRoot,
+		validationConfig.roots,
+		validationConfig.allowlist,
+		validationConfig.excludeGlobs,
+		validationConfig.buildCtx,
+	)
+	if err != nil {
+		tb.Fatalf("collect checked-in repo validation result: %v", err)
+	}
+
+	findingCount := len(repoResult.findings)
+	if findingCount == 0 {
+		tb.Fatal(errExpectedCheckedInRepoFindings)
+	}
+
+	violations, err := ValidateAnyUsageFromFile(
+		checkedInRepo.AllowlistPath,
+		checkedInRepo.Root,
+		checkedInRepo.Roots,
+	)
+	if err != nil {
+		tb.Fatalf(errBenchmarkValidateAnyUsage, err)
+	}
+
+	snapshots := benchtest.LoadPackageSnapshots(
+		tb,
+		checkedInRepo.Root,
+		checkedInRepo.PackagePatterns,
+	)
+	packageCount := len(snapshots)
+	if packageCount == 0 {
+		tb.Fatal("expected checked-in repo benchmark to load packages")
+	}
+
+	resetProcessRepoValidationCacheForTesting()
+	return checkedInRepoBenchmarkFixture{
+		allowlistPath:          checkedInRepo.AllowlistPath,
+		allowlistRelPath:       checkedInRepo.AllowlistRelPath,
+		expectedViolationCount: len(violations),
+		findingCount:           findingCount,
+		packageCount:           packageCount,
+		repoRoot:               checkedInRepo.Root,
+		roots:                  checkedInRepo.Roots,
+		snapshots:              snapshots,
+	}
+}
+
+func checkedInRepoBenchmarkAnalyzerConfig(fixture checkedInRepoBenchmarkFixture) *analyzerConfig {
+	rootsValue := strings.Join(fixture.roots, ",")
+	return &analyzerConfig{
+		allowlistPath: fixture.allowlistRelPath,
+		repoRoot:      fixture.repoRoot,
+		roots:         rootsValue,
+	}
+}
+
+func checkedInRepoValidationBenchmarkName(packageCount, findingCount, violationCount int) string {
+	return fmt.Sprintf(
+		"checked-in-%dpkgs-%dfindings-%dviolations",
+		packageCount,
+		findingCount,
+		violationCount,
+	)
+}
+
+func checkedInRepoAnalyzerBenchmarkName(packageCount, findingCount, diagnosticCount int) string {
+	return fmt.Sprintf(
+		"checked-in-%dpkgs-%dfindings-%ddiagnostics",
+		packageCount,
+		findingCount,
+		diagnosticCount,
+	)
 }
 
 func loadRepresentativeSnapshot(tb testing.TB, fixture benchtest.SyntheticRepo) benchtest.PackageSnapshot {

--- a/internal/validation/execution_model_test.go
+++ b/internal/validation/execution_model_test.go
@@ -11,6 +11,7 @@ const (
 	errValidateAnyUsageFromFile       = "validate any usage from file: %v"
 	errUnexpectedSnapshotCount        = "unexpected package snapshot count: got %d want %d"
 	errExpectedSingleRepoValidation   = "expected one repo-wide validation across package passes, got %d"
+	errExpectedCheckedInRepoSnapshots = "expected checked-in repo package snapshots, got %d"
 	errUnexpectedPerPackageDiagnostic = "unexpected per-package analyzer diagnostics: got %d want %d"
 	errUnexpectedDiagnosticTotal      = "unexpected analyzer diagnostic total across package passes: got %d want %d"
 )
@@ -111,6 +112,55 @@ func TestAnalyzerRunReportsPackageLocalDiagnosticsAndReusesRepoValidation(t *tes
 	}
 	if got, want := totalDiagnostics, len(auditViolations); got != want {
 		t.Fatalf(errUnexpectedDiagnosticTotal, got, want)
+	}
+}
+
+func TestCheckedInRepoAnalyzerReusesRepoValidationAcrossPackageSweep(t *testing.T) {
+	resetProcessRepoValidationCacheForTesting()
+	t.Cleanup(resetProcessRepoValidationCacheForTesting)
+
+	checkedInRepo := benchtest.CurrentCheckedInRepo(t)
+	snapshots := benchtest.LoadPackageSnapshots(t, checkedInRepo.Root, checkedInRepo.PackagePatterns)
+	snapshotCount := len(snapshots)
+	if snapshotCount == 0 {
+		t.Fatalf(errExpectedCheckedInRepoSnapshots, snapshotCount)
+	}
+
+	cfg := &analyzerConfig{
+		allowlistPath: checkedInRepo.AllowlistRelPath,
+		repoRoot:      checkedInRepo.Root,
+		roots:         DefaultRoots,
+	}
+
+	var cache repoValidationCache
+	repoValidationCalls := 0
+	cfg.loadRepoValidation = func(config repoValidationConfig) (repoValidationResult, error) {
+		return cache.load(config.cacheKey, func() (repoValidationResult, error) {
+			repoValidationCalls++
+			return collectRepoValidationResultWithBuildContext(
+				config.repoRoot,
+				config.roots,
+				config.allowlist,
+				config.excludeGlobs,
+				config.buildCtx,
+			)
+		})
+	}
+
+	for _, snapshot := range snapshots {
+		_ = testRunAnalyzerDiagnostics(t, cfg, snapshot)
+	}
+	if repoValidationCalls != 1 {
+		t.Fatalf(errExpectedSingleRepoValidation, repoValidationCalls)
+	}
+
+	// Re-run one representative package after the full sweep to lock the
+	// steady-state cache behavior on the checked-in repository layout.
+	representativeIndex := snapshotCount / 2
+	representativeSnapshot := snapshots[representativeIndex]
+	_ = testRunAnalyzerDiagnostics(t, cfg, representativeSnapshot)
+	if repoValidationCalls != 1 {
+		t.Fatalf(errExpectedSingleRepoValidation, repoValidationCalls)
 	}
 }
 

--- a/plugin/benchmark_test.go
+++ b/plugin/benchmark_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 const errUnexpectedSmokeDiagnosticCount = "unexpected smoke diagnostic count: got %d want %d"
+const errUnexpectedCheckedInRepoModulePluginDiagnostics = "unexpected checked-in repo module-plugin diagnostic count: got %d want %d"
 const expectedSmokeDiagnosticCount = 5
 
 type smokeBenchmarkCase struct {
@@ -54,7 +55,7 @@ func benchmarkModulePluginSmokePath(
 	b.Helper()
 
 	snapshots := loadSmokeSnapshots(b, smokeRoot, patterns, benchmarkCase.loadMode)
-	diagnosticCount := benchmarkSmokeDiagnostics(b, settings, snapshots)
+	diagnosticCount := benchmarkModulePluginDiagnostics(b, settings, snapshots)
 	expectedDiagnosticCount := expectedSmokeDiagnosticCount
 	// The checked-in smoke fixture emits five diagnostics. The shell smoke script
 	// checks the same count.
@@ -70,9 +71,50 @@ func benchmarkModulePluginSmokePath(
 			// Each iteration reloads package inputs. The benchmark includes the
 			// package work selected by the module-plugin load mode.
 			reloadedSnapshots := loadSmokeSnapshots(b, smokeRoot, patterns, benchmarkCase.loadMode)
-			reloadedDiagnosticCount := benchmarkSmokeDiagnostics(b, settings, reloadedSnapshots)
+			reloadedDiagnosticCount := benchmarkModulePluginDiagnostics(b, settings, reloadedSnapshots)
 			if reloadedDiagnosticCount != expectedDiagnosticCount {
 				b.Fatalf(errUnexpectedSmokeDiagnosticCount, reloadedDiagnosticCount, expectedDiagnosticCount)
+			}
+		}
+	})
+}
+
+func BenchmarkCheckedInRepoModulePluginPath(b *testing.B) {
+	checkedInRepo := benchtest.CurrentCheckedInRepo(b)
+	settings := map[string]any{
+		flagAllowlist: checkedInRepo.AllowlistRelPath,
+		flagRepoRoot:  checkedInRepo.Root,
+		flagRoots:     benchmarkPluginRoots(checkedInRepo.Roots),
+	}
+	loadMode := benchtest.PackageLoadModeSyntax
+	snapshots := benchtest.LoadPackageSnapshotsWithMode(
+		b,
+		checkedInRepo.Root,
+		checkedInRepo.PackagePatterns,
+		loadMode,
+	)
+
+	snapshotCount := len(snapshots)
+	if snapshotCount == 0 {
+		b.Fatal("expected checked-in repo module-plugin benchmark to load packages")
+	}
+
+	expectedDiagnosticCount := benchmarkModulePluginDiagnostics(b, settings, snapshots)
+	benchmarkName := fmt.Sprintf("checked-in-%dpkgs-%ddiagnostics", snapshotCount, expectedDiagnosticCount)
+	b.Run(benchmarkName, func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			// Reload syntax snapshots each iteration so the benchmark includes the
+			// same package-loading shape as the module-plugin integration path.
+			reloadedSnapshots := benchtest.LoadPackageSnapshotsWithMode(
+				b,
+				checkedInRepo.Root,
+				checkedInRepo.PackagePatterns,
+				loadMode,
+			)
+			diagnosticCount := benchmarkModulePluginDiagnostics(b, settings, reloadedSnapshots)
+			if diagnosticCount != expectedDiagnosticCount {
+				b.Fatalf(errUnexpectedCheckedInRepoModulePluginDiagnostics, diagnosticCount, expectedDiagnosticCount)
 			}
 		}
 	})
@@ -218,7 +260,7 @@ func loadSmokeGoVersion(tb testing.TB, smokeRoot string) string {
 	return ""
 }
 
-func benchmarkSmokeDiagnostics(tb testing.TB, settings map[string]any, snapshots []benchtest.PackageSnapshot) int {
+func benchmarkModulePluginDiagnostics(tb testing.TB, settings map[string]any, snapshots []benchtest.PackageSnapshot) int {
 	tb.Helper()
 
 	pluginInstance, err := New(settings)
@@ -247,6 +289,14 @@ func benchmarkSmokeDiagnostics(tb testing.TB, settings map[string]any, snapshots
 		}
 	}
 	return diagnosticCount
+}
+
+func benchmarkPluginRoots(roots []string) []any {
+	settingsRoots := make([]any, 0, len(roots))
+	for _, root := range roots {
+		settingsRoots = append(settingsRoots, root)
+	}
+	return settingsRoots
 }
 
 func smokePackagePatterns(tb testing.TB, smokeRoot string) []string {


### PR DESCRIPTION
## Summary

* Add checked-in repo perf-sanity benchmarks for repo-wide validation, cold analyzer sweeps, warm analyzer sweeps, and module-plugin execution
* Add a real-repo analyzer cache-reuse regression test and harden checked-in repo snapshot loading for test-only package sweeps
* Update README, golangci-lint docs, changelog, and CI to document and run the new real-repo benchmark split, including cross-platform timing guidance

Resolves: #70 