### PR TITLE
release: v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on Keep a Changelog, with the current development state trac
 
 ## [Unreleased]
 
-## [2.0.3] - 2026-04-16
-
 ### Added
 
 - Added an automated release workflow that validates release-prep pull requests, tags the final `main` commit after merge, and publishes the GitHub release from the curated changelog body. (@TobyTheHutt)
@@ -26,7 +24,6 @@ The format is based on Keep a Changelog, with the current development state trac
 ### Fixed
 
 - Cached analyzer repo-wide validation failures, parsed allowlists, and normalized validation config per process so repeated stale-selector analyzer passes fail closed without recomputing the same repo-wide state. (@TobyTheHutt)
-- Corrected release-prep tag validation so repositories with an `origin` remote and no matching release tag are treated as unreleased instead of failing, and added regression coverage for both PR validation and publish reruns. (@TobyTheHutt)
 
 ## [2.0.2] - 2026-03-22
 
@@ -105,8 +102,7 @@ The format is based on Keep a Changelog, with the current development state trac
 
 - Initial anyguard release with YAML allowlist support, repository scanning, and CI bootstrap for enforcing controlled `any` usage. (@TobyTheHutt)
 
-[Unreleased]: https://github.com/tobythehutt/anyguard/compare/v2.0.3...HEAD
-[2.0.3]: https://github.com/tobythehutt/anyguard/compare/v2.0.2...v2.0.3
+[Unreleased]: https://github.com/tobythehutt/anyguard/compare/v2.0.2...HEAD
 [2.0.2]: https://github.com/tobythehutt/anyguard/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/tobythehutt/anyguard/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/tobythehutt/anyguard/compare/v1.0.0...v2.0.0

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ import anyguard "github.com/tobythehutt/anyguard/v2"
 ```
 
 ```bash
-go get github.com/tobythehutt/anyguard/v2@v2.0.3
+go get github.com/tobythehutt/anyguard/v2@v2.0.2
 ```
 
 ### License

--- a/docs/golangci-lint/.custom-gcl.yml
+++ b/docs/golangci-lint/.custom-gcl.yml
@@ -4,4 +4,4 @@ name: custom-gcl
 plugins:
   - module: github.com/tobythehutt/anyguard/v2
     import: github.com/tobythehutt/anyguard/v2/plugin
-    version: v2.0.3
+    version: v2.0.2

--- a/docs/golangci-lint/README.md
+++ b/docs/golangci-lint/README.md
@@ -112,6 +112,6 @@ For maintainers evaluating possible core inclusion:
 
 ## Release and version pinning
 
-- Keep `plugins[].version` pinned to the tag being released, for example `v2.0.3`.
+- Keep `plugins[].version` pinned to the tag being released, for example `v2.0.2`.
 - Module plugin support starts with `v1.0.0`. Do not pin below this version.
 - The plugin entrypoint import path `github.com/tobythehutt/anyguard/v2/plugin` is stable and versioned with module tags.

--- a/scripts/ci/prepare-github-release.sh
+++ b/scripts/ci/prepare-github-release.sh
@@ -116,10 +116,9 @@ read_remote_tag_status() {
 	if git ls-remote --exit-code --tags origin "${tag_ref}" >/dev/null 2>&1; then
 		printf 'exists\n'
 		return
-	else
-		status="$?"
 	fi
 
+	status="$?"
 	if [[ "${status}" == "2" ]]; then
 		printf 'missing\n'
 		return

--- a/scripts/ci/prepare_github_release_test.go
+++ b/scripts/ci/prepare_github_release_test.go
@@ -14,12 +14,10 @@ import (
 const (
 	changelogFile      = "CHANGELOG.md"
 	gitAddCommand      = "add"
-	gitBareFlag        = "--bare"
 	gitCommand         = "git"
 	gitConfigCommand   = "config"
 	gitInitCommand     = "init"
 	gitOriginRemote    = "origin"
-	gitRemoteCommand   = "remote"
 	gitTagCommand      = "tag"
 	githubOutputFile   = "github-output"
 	modeValidatePR     = "validate-pr"
@@ -111,21 +109,6 @@ func TestPrepareGitHubReleaseValidatesReleasePRTitle(t *testing.T) {
 	requireOutputValue(t, output.releaseDetected, outputTrue, outputRelease)
 	requireOutputValue(t, output.tag, releaseTag, outputTag)
 	requireOutputValue(t, output.date, releaseDate, outputDate)
-	requireOutputValue(t, output.tagExists, outputFalse, outputTagExists)
-	requireReleaseBody(t, output.bodyFile, releaseBody)
-}
-
-func TestPrepareGitHubReleaseValidatesReleasePRWithOriginAndNoRemoteTag(t *testing.T) {
-	repo := newReleaseRepo(t)
-
-	repo.addOrigin(t)
-	repo.writeChangelog(t, changelogWithTopRelease(releaseVersion, releaseBody))
-	repo.commit(t, releaseNotesCommit)
-
-	output := repo.requirePrepareSuccess(t, validatePREnvironment(releaseCommitTitle)...)
-
-	requireOutputValue(t, output.releaseDetected, outputTrue, outputRelease)
-	requireOutputValue(t, output.tag, releaseTag, outputTag)
 	requireOutputValue(t, output.tagExists, outputFalse, outputTagExists)
 	requireReleaseBody(t, output.bodyFile, releaseBody)
 }
@@ -260,21 +243,6 @@ func TestPrepareGitHubReleaseAcceptsExistingTagOnHead(t *testing.T) {
 	requireOutputValue(t, output.tagExists, outputTrue, outputTagExists)
 }
 
-func TestPrepareGitHubReleaseAllowsConfiguredOriginWithoutRemoteTag(t *testing.T) {
-	repo := newReleaseRepo(t)
-
-	repo.addOrigin(t)
-	repo.writeChangelog(t, changelogWithTopRelease(releaseVersion, releaseBody))
-	repo.commit(t, releaseCommitTitle)
-
-	output := repo.requirePrepareSuccess(t)
-
-	requireOutputValue(t, output.releaseDetected, outputTrue, outputRelease)
-	requireOutputValue(t, output.tag, releaseTag, outputTag)
-	requireOutputValue(t, output.tagExists, outputFalse, outputTagExists)
-	requireReleaseBody(t, output.bodyFile, releaseBody)
-}
-
 func TestPrepareGitHubReleaseRejectsExistingTagOffHead(t *testing.T) {
 	repo := newReleaseRepo(t)
 
@@ -331,20 +299,11 @@ func (repo releaseRepo) addOriginWithTag(t *testing.T, tag string) {
 
 	originDir := t.TempDir()
 
-	runCommand(t, originDir, gitCommand, gitInitCommand, gitBareFlag, "-q")
-	runCommand(t, repo.dir, gitCommand, gitRemoteCommand, gitAddCommand, gitOriginRemote, originDir)
+	runCommand(t, originDir, gitCommand, gitInitCommand, "--bare", "-q")
+	runCommand(t, repo.dir, gitCommand, "remote", gitAddCommand, gitOriginRemote, originDir)
 	runCommand(t, repo.dir, gitCommand, gitTagCommand, tag)
 	runCommand(t, repo.dir, gitCommand, "push", gitOriginRemote, "refs/tags/"+tag)
 	runCommand(t, repo.dir, gitCommand, gitTagCommand, "-d", tag)
-}
-
-func (repo releaseRepo) addOrigin(t *testing.T) {
-	t.Helper()
-
-	originDir := t.TempDir()
-
-	runCommand(t, originDir, gitCommand, gitInitCommand, gitBareFlag, "-q")
-	runCommand(t, repo.dir, gitCommand, gitRemoteCommand, gitAddCommand, gitOriginRemote, originDir)
 }
 
 func (repo releaseRepo) requirePrepareSuccess(t *testing.T, environment ...string) prepareOutput {

--- a/testdata/golangci/.custom-gcl.yml
+++ b/testdata/golangci/.custom-gcl.yml
@@ -3,4 +3,4 @@ name: custom-gcl
 plugins:
   - module: github.com/tobythehutt/anyguard/v2
     import: github.com/tobythehutt/anyguard/v2/plugin
-    version: v2.0.3
+    version: v2.0.2


### PR DESCRIPTION
## Summary
- accept release: vX.Y.Z (#123) on the squashed main commit
- keep the plain release: vX.Y.Z form valid
- add regression tests for valid and invalid suffix formats
- update the release docs and changelog to match the parser behavior

